### PR TITLE
Adds method for computing the centerline.

### DIFF
--- a/include/maliput_sample/geometry/line_string.h
+++ b/include/maliput_sample/geometry/line_string.h
@@ -31,6 +31,7 @@
 
 #include <cmath>
 #include <initializer_list>
+#include <iterator>
 #include <vector>
 
 #include <maliput/common/maliput_throw.h>

--- a/include/maliput_sample/geometry/line_string.h
+++ b/include/maliput_sample/geometry/line_string.h
@@ -73,9 +73,6 @@ class LineString final {
   using iterator = typename std::vector<CoordinateT>::iterator;
   using const_iterator = typename std::vector<CoordinateT>::const_iterator;
 
-  /// Default constructor.
-  LineString() = default;
-
   /// Constructs a LineString from a std::vector.
   ///
   /// This function calls LineString(coordinates.begin, coordinates.end)
@@ -123,14 +120,6 @@ class LineString final {
   /// @return The accumulated length between consecutive points in this LineString by means of DistanceFunction.
   double length() const { return length_; }
 
-  /// Pushes @p coordiante into the line string.
-  void push_back(const CoordinateT& coordinate) {
-    coordinates_.push_back(coordinate);
-    if (coordinates_.size() > 1) {
-      length_ += DistanceFunction()(coordinates_[coordinates_.size() - 2], coordinates_.back());
-    }
-  }
-
   /// @returns begin iterator of the underlying collection.
   iterator begin() { return coordinates_.begin(); }
   /// @returns begin const iterator of the underlying collection.
@@ -145,15 +134,7 @@ class LineString final {
 
   /// Equality operator.
   bool operator==(const LineString<CoordinateT, DistanceFunction>& other) const {
-    if (other.size() != size()) {
-      return false;
-    };
-    for (std::size_t i = 0; i < size(); ++i) {
-      if (operator[](i) != other[i]) {
-        return false;
-      }
-    }
-    return true;
+    return coordinates_ == other.coordinates_;
   }
 
  private:

--- a/include/maliput_sample/geometry/line_string.h
+++ b/include/maliput_sample/geometry/line_string.h
@@ -70,6 +70,9 @@ struct EuclideanDistance {
 template <typename CoordinateT, typename DistanceFunction = details::EuclideanDistance<CoordinateT>>
 class LineString final {
  public:
+  using iterator = typename std::vector<CoordinateT>::iterator;
+  using const_iterator = typename std::vector<CoordinateT>::const_iterator;
+
   /// Constructs a LineString from a std::vector.
   ///
   /// This function calls LineString(coordinates.begin, coordinates.end)
@@ -101,6 +104,8 @@ class LineString final {
     length_ = ComputeLength();
   }
 
+  LineString() = default;
+
   /// @return The first point in the LineString.
   const CoordinateT& first() const { return coordinates_.front(); }
 
@@ -116,6 +121,39 @@ class LineString final {
 
   /// @return The accumulated length between consecutive points in this LineString by means of DistanceFunction.
   double length() const { return length_; }
+
+  void push_back(const CoordinateT& coordinate) {
+    coordinates_.push_back(coordinate);
+    if (coordinates_.size() > 1) {
+      length_ += DistanceFunction()(coordinates_[coordinates_.size() - 2], coordinates_.back());
+    }
+  }
+
+  iterator begin() { return coordinates_.begin(); }
+  const_iterator begin() const { return coordinates_.begin(); }
+  iterator end() { return coordinates_.end(); }
+  const_iterator end() const { return coordinates_.end(); }
+
+  const CoordinateT& operator[](std::size_t index) const {
+    // MALIPUT_THROW_UNLESS(index < coordinates_.size());
+    return coordinates_[index];
+  }
+  CoordinateT& operator[](std::size_t index) {
+    // MALIPUT_THROW_UNLESS(index < coordinates_.size());
+    return coordinates_[index];
+  }
+
+  bool operator==(const LineString<CoordinateT, DistanceFunction>& other) const {
+    if (other.size() != size()) {
+      return false;
+    };
+    for (std::size_t i = 0; i < size(); ++i) {
+      if (operator[](i) != other[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
 
  private:
   // @return The accumulated Length of this LineString.

--- a/include/maliput_sample/geometry/line_string.h
+++ b/include/maliput_sample/geometry/line_string.h
@@ -73,6 +73,9 @@ class LineString final {
   using iterator = typename std::vector<CoordinateT>::iterator;
   using const_iterator = typename std::vector<CoordinateT>::const_iterator;
 
+  /// Default constructor.
+  LineString() = default;
+
   /// Constructs a LineString from a std::vector.
   ///
   /// This function calls LineString(coordinates.begin, coordinates.end)
@@ -104,8 +107,6 @@ class LineString final {
     length_ = ComputeLength();
   }
 
-  LineString() = default;
-
   /// @return The first point in the LineString.
   const CoordinateT& first() const { return coordinates_.front(); }
 
@@ -122,6 +123,7 @@ class LineString final {
   /// @return The accumulated length between consecutive points in this LineString by means of DistanceFunction.
   double length() const { return length_; }
 
+  /// Pushes @p coordiante into the line string.
   void push_back(const CoordinateT& coordinate) {
     coordinates_.push_back(coordinate);
     if (coordinates_.size() > 1) {
@@ -129,20 +131,19 @@ class LineString final {
     }
   }
 
+  /// @returns begin iterator of the underlying collection.
   iterator begin() { return coordinates_.begin(); }
+  /// @returns begin const iterator of the underlying collection.
   const_iterator begin() const { return coordinates_.begin(); }
+  /// @returns end iterator of the underlying collection.
   iterator end() { return coordinates_.end(); }
+  /// @returns end const iterator of the underlying collection.
   const_iterator end() const { return coordinates_.end(); }
 
-  const CoordinateT& operator[](std::size_t index) const {
-    // MALIPUT_THROW_UNLESS(index < coordinates_.size());
-    return coordinates_[index];
-  }
-  CoordinateT& operator[](std::size_t index) {
-    // MALIPUT_THROW_UNLESS(index < coordinates_.size());
-    return coordinates_[index];
-  }
+  const CoordinateT& operator[](std::size_t index) const { return coordinates_[index]; }
+  CoordinateT& operator[](std::size_t index) { return coordinates_[index]; }
 
+  /// Equality operator.
   bool operator==(const LineString<CoordinateT, DistanceFunction>& other) const {
     if (other.size() != size()) {
       return false;

--- a/include/maliput_sample/geometry/utility/geometry.h
+++ b/include/maliput_sample/geometry/utility/geometry.h
@@ -37,6 +37,13 @@ namespace maliput_sample {
 namespace geometry {
 namespace utility {
 
+/// Computes a 3-dimensional centerline out of the @p left and @p right line string.
+///
+/// Inspired on https://github.com/fzi-forschungszentrum-informatik/Lanelet2/blob/master/lanelet2_core/src/Lanelet.cpp
+///
+/// @param left Left line string.
+/// @param right Right line string.
+/// @returns The centerline.
 LineString3d ComputeCenterline3d(const LineString3d& left, const LineString3d& right);
 
 }  // namespace utility

--- a/include/maliput_sample/geometry/utility/geometry.h
+++ b/include/maliput_sample/geometry/utility/geometry.h
@@ -1,0 +1,44 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <optional>
+
+#include "maliput_sample/geometry/line_string.h"
+
+namespace maliput_sample {
+namespace geometry {
+namespace utility {
+
+LineString3d ComputeCenterline3d(const LineString3d& left, const LineString3d& right);
+
+}  // namespace utility
+}  // namespace geometry
+}  // namespace maliput_sample

--- a/src/geometry/CMakeLists.txt
+++ b/src/geometry/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 set(GEOMETRY_SOURCES
   line_string.cc
+  utility/geometry.cc
 )
 
 add_library(geometry ${GEOMETRY_SOURCES})

--- a/src/geometry/utility/geometry.cc
+++ b/src/geometry/utility/geometry.cc
@@ -1,0 +1,316 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "maliput_sample/geometry/utility/geometry.h"
+
+namespace maliput_sample {
+namespace geometry {
+namespace utility {
+
+using OptDistance = std::optional<double>;
+using Segment3d = std::pair<maliput::math::Vector3, maliput::math::Vector3>;
+using Segment2d = std::pair<maliput::math::Vector2, maliput::math::Vector2>;
+
+namespace {
+
+bool SegmentsIntersect2d(const Segment2d& lhs, const Segment2d& rhs) {
+  const auto& x1 = lhs.first[0];
+  const auto& y1 = lhs.first[1];
+  const auto& x2 = lhs.second[0];
+  const auto& y2 = lhs.second[1];
+  const auto& x3 = rhs.first[0];
+  const auto& y3 = rhs.first[1];
+  const auto& x4 = rhs.second[0];
+  const auto& y4 = rhs.second[1];
+
+  double d = (x1 - x2) * (y3 - y4) - (y1 - y2) * (x3 - x4);
+  // If denominator is zero, the segments are parallel or coincident.
+  return d != 0;
+}
+
+bool PointIsLeftOf(const maliput::math::Vector3& pSeg1, const maliput::math::Vector3& pSeg2,
+                   const maliput::math::Vector3& p) {
+  return ((pSeg2 - pSeg1).cross(p - pSeg1)).z() > 0;
+}
+
+Segment2d To2d(const Segment3d& segment) {
+  return {{segment.first.x(), segment.first.y()}, {segment.second.x(), segment.second.y()}};
+}
+
+class BoundChecker {
+ public:
+  BoundChecker(const LineString3d& left, const LineString3d& right)
+      : left_(left), right_(right), entry_{right.first(), left.first()}, exit_{left.last(), right.last()} {
+    left_segments_ = MakeSegments(left_);
+    right_segments_ = MakeSegments(right_);
+  }
+
+  bool Intersects2d(const Segment3d& seg) const {
+    const Segment2d seg2d{{seg.first.x(), seg.first.y()}, {seg.second.x(), seg.second.y()}};
+    const bool result =
+        IntersectsLeft2d(seg2d) || IntersectsRight2d(seg2d) || CrossesEntry2d(seg2d) || CrossesExit2d(seg2d);
+    return result;
+  }
+
+  bool IntersectsLeft2d(const Segment2d& seg) const {
+    for (const auto left_segment : left_segments_) {
+      const Segment2d left_seg{{left_segment.first.x(), left_segment.first.y()},
+                               {left_segment.second.x(), left_segment.second.y()}};
+      if (SegmentsIntersect2d(seg, left_seg)) {
+        if (!(seg.first == left_seg.first)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  bool IntersectsRight2d(const Segment2d& seg) const {
+    for (const auto right_segment : right_segments_) {
+      const Segment2d right_seg{{right_segment.first.x(), right_segment.first.y()},
+                                {right_segment.second.x(), right_segment.second.y()}};
+      if (SegmentsIntersect2d(seg, right_seg)) {
+        if (!(seg.first == right_seg.first)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  bool SecondCrossesBounds(const Segment2d& seg, bool left) const {
+    const auto& segments = left ? left_segments_ : right_segments_;
+    for (const auto& segment : segments) {
+      if (SegmentsIntersect2d(To2d(segment), seg)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool CrossesEntry2d(const Segment2d& seg) const {
+    const Segment2d entry_2d{{entry_.first.x(), entry_.first.y()}, {entry_.second.x(), entry_.second.y()}};
+    if (SegmentsIntersect2d(seg, entry_2d)) {
+      PointIsLeftOf(maliput::math::Vector3{entry_2d.first.x(), entry_2d.first.y(), 0.},
+                    maliput::math::Vector3{entry_2d.second.x(), entry_2d.second.y(), 0.},
+                    maliput::math::Vector3{seg.second.x(), seg.second.y(), 0.});
+    }
+    return false;
+  }
+
+  bool CrossesExit2d(const Segment2d& seg) const {
+    const Segment2d exit_2d{{exit_.first.x(), exit_.first.y()}, {exit_.second.x(), exit_.second.y()}};
+    if (SegmentsIntersect2d(seg, exit_2d)) {
+      PointIsLeftOf(maliput::math::Vector3{exit_2d.first.x(), exit_2d.first.y(), 0.},
+                    maliput::math::Vector3{exit_2d.second.x(), exit_2d.second.y(), 0.},
+                    maliput::math::Vector3{seg.second.x(), seg.second.y(), 0.});
+    }
+    return false;
+  }
+
+  template <typename Func>
+  void ForEachPointLeftUntil(LineString3d::const_iterator iter, Func&& f) const {
+    return ForEachPointUntilImpl(iter, left_, std::forward<Func>(f));
+  }
+  template <typename Func>
+  void ForEachPointRightUntil(LineString3d::const_iterator iter, Func&& f) const {
+    return ForEachPointUntilImpl(iter, right_, std::forward<Func>(f));
+  }
+
+ private:
+  static std::vector<Segment3d> MakeSegments(const LineString3d& line) {
+    std::vector<Segment3d> segments;
+    segments.reserve(line.size());
+    for (auto i = 0u; i < line.size() - 2; ++i) {
+      segments.push_back({line[i], line[i + 1]});
+    }
+    return segments;
+  }
+
+  template <typename Func>
+  static void ForEachPointUntilImpl(LineString3d::const_iterator iter, const LineString3d& points, Func&& f) {
+    for (auto iter = points.begin(); iter != points.end(); ++iter) {
+      if (f(iter)) {
+        break;
+      }
+    }
+  }
+
+  const LineString3d& left_;
+  const LineString3d& right_;
+  Segment3d entry_, exit_;
+  std::vector<Segment3d> left_segments_;
+  std::vector<Segment3d> right_segments_;
+};
+
+maliput::math::Vector3 MakeCenterpoint(const maliput::math::Vector3& p1, const maliput::math::Vector3& p2) {
+  return (p1 + p2) / 2.;
+}
+
+std::pair<LineString3d::const_iterator, OptDistance> FindClosestNonintersectingPoint(
+    LineString3d::const_iterator current_position, LineString3d::const_iterator other_point, const BoundChecker& bounds,
+    const maliput::math::Vector3& last_point, bool is_left) {
+  std::cout << "\t\t[FindClosestNonintersectingPoint]: side: " << (is_left ? "left" : "right")
+            << " - Current position: " << *current_position << " other_point: " << *other_point
+            << " last_center_point: " << last_point << std::endl;
+  OptDistance distance;
+  LineString3d::const_iterator closest_position{nullptr};
+  double d_last_other = (*other_point - last_point).norm();
+  std::cout << "\t\td_last_other: " << d_last_other << std::endl;
+
+  // this lambda is called with points of increasing distance to other_point
+  auto nonintersectingPointLoop = [&](LineString3d::const_iterator candidate) {
+    std::cout << "\t\t\tcandidate: " << *candidate << std::endl;
+    // point must be after current_position
+
+    if (candidate < current_position) {
+      std::cout << "\t\t\t\tcandidate <= current_position" << std::endl;
+      return false;
+    }
+    // we use the triangle inequation to find a distance where we can not
+    // expect a closer point than the current one
+    if (!!distance && (*other_point - *candidate).norm() / 2 - d_last_other > *distance) {
+      std::cout << "\t\t\t\t!!distance && (*other_point - *candidate).norm() / 2 - d_last_other > *distance"
+                << std::endl;
+      return true;  // stops the loop
+    }
+    auto candidate_distance = (*candidate - *other_point).norm() / 2;  // candidate distance
+    if (!!distance && *distance <= candidate_distance) {
+      std::cout << "\t\t\t\t!!distance && *distance <= candidate_distance" << std::endl;
+      return false;
+    }
+    // Candidates are only valid candidates if
+    // 1. their distance is minimal (at least for now) -> checked above
+    // 2. the new connection does not intersect with the borders
+    // 3. connection between point on one bound and point on other bound
+    // does not intersect with other parts of the boundary
+    Segment3d bound_connection(*other_point, *candidate);
+    Segment3d inv_bound_connection(bound_connection.second, bound_connection.first);
+    auto centerline_point_candidate = MakeCenterpoint(bound_connection.first, bound_connection.second);
+    std::cout << "\t\t\tcenterline_point_candidate: " << centerline_point_candidate << std::endl;
+    Segment3d centerline_candidate{last_point, centerline_point_candidate};
+    if (!bounds.Intersects2d(centerline_candidate) /*&& !bounds.SecondCrossesBounds(To2d(bound_connection), is_left)   &&
+       !bounds.SecondCrossesBounds(To2d(inv_bound_connection), !is_left)*/) {
+      distance = candidate_distance;
+      closest_position = candidate;
+      std::cout << "\t\t\t\tcandidated taken." << std::endl;
+      std::cout << "\t\t\t\t\tdistance: " << *distance << std::endl;
+    }
+    return false;
+  };
+  if (is_left) {
+    std::cout << "\t\tloop in left: " << std::endl;
+    bounds.ForEachPointLeftUntil(other_point,
+                                 nonintersectingPointLoop);  // For each point in the left string to other_point
+  } else {
+    std::cout << "\t\tloop in right: " << std::endl;
+    bounds.ForEachPointRightUntil(other_point, nonintersectingPointLoop);
+  }
+  return {closest_position, distance};
+}
+
+}  // namespace
+
+LineString3d ComputeCenterline3d(const LineString3d& left, const LineString3d& right) {
+  LineString3d centerline;
+  std::cout << "[ComputeCenterline3d]" << std::endl;
+  BoundChecker bounds(left, right);
+  // Initial point
+  centerline.push_back(MakeCenterpoint(left.first(), right.first()));
+
+  auto left_current = left.begin();
+  auto right_current = right.begin();
+
+  while (left_current != left.end() || right_current != right.end()) {
+    std::cout << "\twhile loop: left_current: " << *left_current << " - right_current: " << *right_current << std::endl;
+    std::optional<double> left_candidate_distance;
+    std::optional<double> right_candidate_distance;
+
+    LineString3d::const_iterator left_candidate;
+    LineString3d::const_iterator right_candidate;
+    // Determine left candidate
+    std::tie(left_candidate, left_candidate_distance) =
+        FindClosestNonintersectingPoint(std::next(left_current), right_current, bounds, centerline.last(), true);
+    std::cout << "\tleft_candidate: "
+              << (left_candidate == LineString3d::const_iterator{nullptr} ? "None" : (*left_candidate).to_str())
+              << std::endl;
+    std::cout << "\tleft_candidate_distance: "
+              << (left_candidate_distance.has_value() ? std::to_string(*left_candidate_distance) : "std::nullopt")
+              << std::endl;
+
+    // Determine right candidate
+    std::tie(right_candidate, right_candidate_distance) =
+        FindClosestNonintersectingPoint(std::next(right_current), left_current, bounds, centerline.last(), false);
+    std::cout << "\tright_candidate: "
+              << (right_candidate == LineString3d::const_iterator{nullptr} ? "None" : (*right_candidate).to_str())
+              << std::endl;
+    std::cout << "\tright_candidate_distance: "
+              << (right_candidate_distance.has_value() ? std::to_string(*right_candidate_distance) : "std::nullopt")
+              << std::endl;
+    // Choose the better one
+    if (left_candidate_distance && (!right_candidate_distance || left_candidate_distance <= right_candidate_distance)) {
+      MALIPUT_THROW_UNLESS(left_candidate != left.end());
+
+      const auto& left_point = left[size_t(left_candidate - left.begin())];
+      std::cout << "\tleft_point: " << left_point << std::endl;
+      const auto& right_point = right[size_t(right_current - right.begin())];
+      std::cout << "\tright_point: " << right_point << std::endl;
+      const auto centerpoint = MakeCenterpoint(left_point, right_point);
+      std::cout << "\tcenterpoint: " << centerpoint << std::endl;
+      centerline.push_back(centerpoint);
+      left_current = left_candidate;
+    } else if (right_candidate_distance &&
+               (!left_candidate_distance || left_candidate_distance > right_candidate_distance)) {
+      MALIPUT_THROW_UNLESS(right_candidate != right.end());
+
+      const auto& left_point = left[size_t(left_current - left.begin())];
+      std::cout << "\tleft_point: " << left_point << std::endl;
+      const auto& right_point = right[size_t(right_candidate - right.begin())];
+      std::cout << "\tright_point: " << right_point << std::endl;
+      const auto centerpoint = MakeCenterpoint(left_point, right_point);
+      std::cout << "\tcenterpoint: " << centerpoint << std::endl;
+      centerline.push_back(centerpoint);
+      right_current = right_candidate;
+    } else {
+      // no next point found. We are done here
+      break;
+    }
+  }
+
+  // we want the centerpoint defined by the endpoints inside in any case
+  if (!(left_current == std::prev(left.end()) && right_current == std::prev(right.end()))) {
+    centerline.push_back(MakeCenterpoint(left.last(), right.last()));
+  }
+  return centerline;
+}
+
+}  // namespace utility
+}  // namespace geometry
+}  // namespace maliput_sample

--- a/src/geometry/utility/geometry.cc
+++ b/src/geometry/utility/geometry.cc
@@ -122,24 +122,17 @@ class BoundChecker {
 
   bool Intersects2d(const Segment3d& seg) const {
     const Segment2d seg2d{{seg.first.x(), seg.first.y()}, {seg.second.x(), seg.second.y()}};
-    return IntersectsLeft2d(seg2d) || IntersectsRight2d(seg2d) || CrossesEntry2d(seg2d) || CrossesExit2d(seg2d);
+    return Intersects2dSegments(kLeft, seg2d) || Intersects2dSegments(kRight, seg2d) || CrossesEntry2d(seg2d) ||
+           CrossesExit2d(seg2d);
   }
 
-  bool IntersectsLeft2d(const Segment2d& seg) const {
-    const auto it = std::find_if(left_segments_.begin(), left_segments_.end(), [&seg](const Segment3d& left_segment) {
-      const Segment2d left_segment_2d{To2D(left_segment)};
-      return SegmentsIntersect2d(seg, left_segment_2d) ? !(seg.first == left_segment_2d.first) : false;
+  bool Intersects2dSegments(bool use_left_segments, const Segment2d& seg) const {
+    const auto& segments = use_left_segments ? left_segments_ : right_segments_;
+    const auto it = std::find_if(segments.begin(), segments.end(), [&seg](const Segment3d& segment) {
+      const Segment2d segment_2d{To2D(segment)};
+      return SegmentsIntersect2d(seg, segment_2d) ? !(seg.first == segment_2d.first) : false;
     });
-    return it != left_segments_.end();
-  }
-
-  bool IntersectsRight2d(const Segment2d& seg) const {
-    const auto it =
-        std::find_if(right_segments_.begin(), right_segments_.end(), [&seg](const Segment3d& right_segment) {
-          const Segment2d right_segment_2d{To2D(right_segment)};
-          return SegmentsIntersect2d(seg, right_segment_2d) ? !(seg.first == right_segment_2d.first) : false;
-        });
-    return it != right_segments_.end();
+    return it != segments.end();
   }
 
   bool CrossesEntry2d(const Segment2d& seg) const {

--- a/src/geometry/utility/geometry.cc
+++ b/src/geometry/utility/geometry.cc
@@ -1,3 +1,31 @@
+// Code in this file is inspired by:
+// https://github.com/fzi-forschungszentrum-informatik/Lanelet2/blob/master/lanelet2_core/src/Lanelet.cpp
+//
+// Lanelet2's license follows:
+//
+// Copyright 2018 FZI Forschungszentrum Informatik
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//
 // BSD 3-Clause License
 //
 // Copyright (c) 2022, Woven Planet.
@@ -40,6 +68,9 @@ using Segment2d = std::pair<maliput::math::Vector2, maliput::math::Vector2>;
 
 namespace {
 
+// Determines whether two line segments intersects.
+//
+// Based on https://en.wikipedia.org/wiki/Line%E2%80%93line_intersection#Given_two_points_on_each_line_segment
 bool SegmentsIntersect2d(const Segment2d& lhs, const Segment2d& rhs) {
   const auto& x1 = lhs.first[0];
   const auto& y1 = lhs.first[1];
@@ -49,21 +80,36 @@ bool SegmentsIntersect2d(const Segment2d& lhs, const Segment2d& rhs) {
   const auto& y3 = rhs.first[1];
   const auto& x4 = rhs.second[0];
   const auto& y4 = rhs.second[1];
-
-  double d = (x1 - x2) * (y3 - y4) - (y1 - y2) * (x3 - x4);
-  // If denominator is zero, the segments are parallel or coincident.
-  return d != 0;
+  const double den = (x1 - x2) * (y3 - y4) - (y1 - y2) * (x3 - x4);
+  if (den == 0) {
+    // They are parallel or coincident.
+    return false;
+  }
+  const double t_num = (x1 - x3) * (y3 - y4) - (y1 - y3) * (x3 - x4);
+  const double u_num = (x1 - x3) * (y1 - y2) - (y1 - y3) * (x1 - x2);
+  const double t = t_num / den;
+  const double u = u_num / den;
+  return (t >= 0 && t <= 1 && u >= 0 && u <= 1);
 }
 
-bool PointIsLeftOf(const maliput::math::Vector3& pSeg1, const maliput::math::Vector3& pSeg2,
+// Obtains the distance between @p lhs and @p rhs points projected on the xy plane.
+double Distance2d(const maliput::math::Vector3& lhs, const maliput::math::Vector3& rhs) {
+  const maliput::math::Vector2 lhs_2d{lhs.x(), lhs.y()};
+  const maliput::math::Vector2 rhs_2d{rhs.x(), rhs.y()};
+  return (lhs_2d - rhs_2d).norm();
+}
+
+// Determines whether point @p p is located left from segment compound by @p seg_first and @p seg_second.
+bool PointIsLeftOf(const maliput::math::Vector3& seg_first, const maliput::math::Vector3& seg_second,
                    const maliput::math::Vector3& p) {
-  return ((pSeg2 - pSeg1).cross(p - pSeg1)).z() > 0;
+  return ((seg_second - seg_first).cross(p - seg_first)).z() > 0;
 }
 
-Segment2d To2d(const Segment3d& segment) {
-  return {{segment.first.x(), segment.first.y()}, {segment.second.x(), segment.second.y()}};
+maliput::math::Vector3 MakeCenterpoint(const maliput::math::Vector3& p1, const maliput::math::Vector3& p2) {
+  return (p1 + p2) / 2.;
 }
 
+// Helper class for evaluating the boundaries of a lane.
 class BoundChecker {
  public:
   BoundChecker(const LineString3d& left, const LineString3d& right)
@@ -96,7 +142,7 @@ class BoundChecker {
     for (const auto right_segment : right_segments_) {
       const Segment2d right_seg{{right_segment.first.x(), right_segment.first.y()},
                                 {right_segment.second.x(), right_segment.second.y()}};
-      if (SegmentsIntersect2d(seg, right_seg)) {
+      if (SegmentsIntersect2d(right_seg, seg)) {
         if (!(seg.first == right_seg.first)) {
           return true;
         }
@@ -105,22 +151,11 @@ class BoundChecker {
     return false;
   }
 
-  bool SecondCrossesBounds(const Segment2d& seg, bool left) const {
-    const auto& segments = left ? left_segments_ : right_segments_;
-    for (const auto& segment : segments) {
-      if (SegmentsIntersect2d(To2d(segment), seg)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   bool CrossesEntry2d(const Segment2d& seg) const {
     const Segment2d entry_2d{{entry_.first.x(), entry_.first.y()}, {entry_.second.x(), entry_.second.y()}};
     if (SegmentsIntersect2d(seg, entry_2d)) {
-      PointIsLeftOf(maliput::math::Vector3{entry_2d.first.x(), entry_2d.first.y(), 0.},
-                    maliput::math::Vector3{entry_2d.second.x(), entry_2d.second.y(), 0.},
-                    maliput::math::Vector3{seg.second.x(), seg.second.y(), 0.});
+      return PointIsLeftOf({entry_2d.first.x(), entry_2d.first.y(), 0.}, {entry_2d.second.x(), entry_2d.second.y(), 0.},
+                           {seg.second.x(), seg.second.y(), 0.});
     }
     return false;
   }
@@ -128,9 +163,8 @@ class BoundChecker {
   bool CrossesExit2d(const Segment2d& seg) const {
     const Segment2d exit_2d{{exit_.first.x(), exit_.first.y()}, {exit_.second.x(), exit_.second.y()}};
     if (SegmentsIntersect2d(seg, exit_2d)) {
-      PointIsLeftOf(maliput::math::Vector3{exit_2d.first.x(), exit_2d.first.y(), 0.},
-                    maliput::math::Vector3{exit_2d.second.x(), exit_2d.second.y(), 0.},
-                    maliput::math::Vector3{seg.second.x(), seg.second.y(), 0.});
+      PointIsLeftOf({exit_2d.first.x(), exit_2d.first.y(), 0.}, {exit_2d.second.x(), exit_2d.second.y(), 0.},
+                    {seg.second.x(), seg.second.y(), 0.});
     }
     return false;
   }
@@ -170,40 +204,25 @@ class BoundChecker {
   std::vector<Segment3d> right_segments_;
 };
 
-maliput::math::Vector3 MakeCenterpoint(const maliput::math::Vector3& p1, const maliput::math::Vector3& p2) {
-  return (p1 + p2) / 2.;
-}
-
 std::pair<LineString3d::const_iterator, OptDistance> FindClosestNonintersectingPoint(
     LineString3d::const_iterator current_position, LineString3d::const_iterator other_point, const BoundChecker& bounds,
     const maliput::math::Vector3& last_point, bool is_left) {
-  std::cout << "\t\t[FindClosestNonintersectingPoint]: side: " << (is_left ? "left" : "right")
-            << " - Current position: " << *current_position << " other_point: " << *other_point
-            << " last_center_point: " << last_point << std::endl;
   OptDistance distance;
   LineString3d::const_iterator closest_position{nullptr};
   double d_last_other = (*other_point - last_point).norm();
-  std::cout << "\t\td_last_other: " << d_last_other << std::endl;
 
-  // this lambda is called with points of increasing distance to other_point
-  auto nonintersectingPointLoop = [&](LineString3d::const_iterator candidate) {
-    std::cout << "\t\t\tcandidate: " << *candidate << std::endl;
+  auto non_intersecting_point_loop = [&](LineString3d::const_iterator candidate) {
     // point must be after current_position
-
     if (candidate < current_position) {
-      std::cout << "\t\t\t\tcandidate <= current_position" << std::endl;
       return false;
     }
+    const auto candidate_distance = Distance2d(*candidate, *other_point) / 2;  // candidate distance
     // we use the triangle inequation to find a distance where we can not
-    // expect a closer point than the current one
-    if (!!distance && (*other_point - *candidate).norm() / 2 - d_last_other > *distance) {
-      std::cout << "\t\t\t\t!!distance && (*other_point - *candidate).norm() / 2 - d_last_other > *distance"
-                << std::endl;
+    // expect a closer point than the current one.
+    if (!!distance && candidate_distance / 2 - d_last_other > *distance) {
       return true;  // stops the loop
     }
-    auto candidate_distance = (*candidate - *other_point).norm() / 2;  // candidate distance
     if (!!distance && *distance <= candidate_distance) {
-      std::cout << "\t\t\t\t!!distance && *distance <= candidate_distance" << std::endl;
       return false;
     }
     // Candidates are only valid candidates if
@@ -211,27 +230,20 @@ std::pair<LineString3d::const_iterator, OptDistance> FindClosestNonintersectingP
     // 2. the new connection does not intersect with the borders
     // 3. connection between point on one bound and point on other bound
     // does not intersect with other parts of the boundary
-    Segment3d bound_connection(*other_point, *candidate);
-    Segment3d inv_bound_connection(bound_connection.second, bound_connection.first);
-    auto centerline_point_candidate = MakeCenterpoint(bound_connection.first, bound_connection.second);
-    std::cout << "\t\t\tcenterline_point_candidate: " << centerline_point_candidate << std::endl;
-    Segment3d centerline_candidate{last_point, centerline_point_candidate};
-    if (!bounds.Intersects2d(centerline_candidate) /*&& !bounds.SecondCrossesBounds(To2d(bound_connection), is_left)   &&
-       !bounds.SecondCrossesBounds(To2d(inv_bound_connection), !is_left)*/) {
+    const Segment3d bound_connection(*other_point, *candidate);
+    const auto centerline_point_candidate = MakeCenterpoint(bound_connection.first, bound_connection.second);
+    const Segment3d centerline_candidate{last_point, centerline_point_candidate};
+    if (!bounds.Intersects2d(centerline_candidate)) {
       distance = candidate_distance;
       closest_position = candidate;
-      std::cout << "\t\t\t\tcandidated taken." << std::endl;
-      std::cout << "\t\t\t\t\tdistance: " << *distance << std::endl;
     }
     return false;
   };
   if (is_left) {
-    std::cout << "\t\tloop in left: " << std::endl;
     bounds.ForEachPointLeftUntil(other_point,
-                                 nonintersectingPointLoop);  // For each point in the left string to other_point
+                                 non_intersecting_point_loop);  // For each point in the left string to other_point
   } else {
-    std::cout << "\t\tloop in right: " << std::endl;
-    bounds.ForEachPointRightUntil(other_point, nonintersectingPointLoop);
+    bounds.ForEachPointRightUntil(other_point, non_intersecting_point_loop);
   }
   return {closest_position, distance};
 }
@@ -240,7 +252,6 @@ std::pair<LineString3d::const_iterator, OptDistance> FindClosestNonintersectingP
 
 LineString3d ComputeCenterline3d(const LineString3d& left, const LineString3d& right) {
   LineString3d centerline;
-  std::cout << "[ComputeCenterline3d]" << std::endl;
   BoundChecker bounds(left, right);
   // Initial point
   centerline.push_back(MakeCenterpoint(left.first(), right.first()));
@@ -249,7 +260,6 @@ LineString3d ComputeCenterline3d(const LineString3d& left, const LineString3d& r
   auto right_current = right.begin();
 
   while (left_current != left.end() || right_current != right.end()) {
-    std::cout << "\twhile loop: left_current: " << *left_current << " - right_current: " << *right_current << std::endl;
     std::optional<double> left_candidate_distance;
     std::optional<double> right_candidate_distance;
 
@@ -258,32 +268,17 @@ LineString3d ComputeCenterline3d(const LineString3d& left, const LineString3d& r
     // Determine left candidate
     std::tie(left_candidate, left_candidate_distance) =
         FindClosestNonintersectingPoint(std::next(left_current), right_current, bounds, centerline.last(), true);
-    std::cout << "\tleft_candidate: "
-              << (left_candidate == LineString3d::const_iterator{nullptr} ? "None" : (*left_candidate).to_str())
-              << std::endl;
-    std::cout << "\tleft_candidate_distance: "
-              << (left_candidate_distance.has_value() ? std::to_string(*left_candidate_distance) : "std::nullopt")
-              << std::endl;
 
     // Determine right candidate
     std::tie(right_candidate, right_candidate_distance) =
         FindClosestNonintersectingPoint(std::next(right_current), left_current, bounds, centerline.last(), false);
-    std::cout << "\tright_candidate: "
-              << (right_candidate == LineString3d::const_iterator{nullptr} ? "None" : (*right_candidate).to_str())
-              << std::endl;
-    std::cout << "\tright_candidate_distance: "
-              << (right_candidate_distance.has_value() ? std::to_string(*right_candidate_distance) : "std::nullopt")
-              << std::endl;
     // Choose the better one
     if (left_candidate_distance && (!right_candidate_distance || left_candidate_distance <= right_candidate_distance)) {
       MALIPUT_THROW_UNLESS(left_candidate != left.end());
 
       const auto& left_point = left[size_t(left_candidate - left.begin())];
-      std::cout << "\tleft_point: " << left_point << std::endl;
       const auto& right_point = right[size_t(right_current - right.begin())];
-      std::cout << "\tright_point: " << right_point << std::endl;
       const auto centerpoint = MakeCenterpoint(left_point, right_point);
-      std::cout << "\tcenterpoint: " << centerpoint << std::endl;
       centerline.push_back(centerpoint);
       left_current = left_candidate;
     } else if (right_candidate_distance &&
@@ -291,11 +286,8 @@ LineString3d ComputeCenterline3d(const LineString3d& left, const LineString3d& r
       MALIPUT_THROW_UNLESS(right_candidate != right.end());
 
       const auto& left_point = left[size_t(left_current - left.begin())];
-      std::cout << "\tleft_point: " << left_point << std::endl;
       const auto& right_point = right[size_t(right_candidate - right.begin())];
-      std::cout << "\tright_point: " << right_point << std::endl;
       const auto centerpoint = MakeCenterpoint(left_point, right_point);
-      std::cout << "\tcenterpoint: " << centerpoint << std::endl;
       centerline.push_back(centerpoint);
       right_current = right_candidate;
     } else {

--- a/src/geometry/utility/geometry.cc
+++ b/src/geometry/utility/geometry.cc
@@ -62,52 +62,54 @@ namespace maliput_sample {
 namespace geometry {
 namespace utility {
 
+using maliput::math::Vector2;
+using maliput::math::Vector3;
 using OptDistance = std::optional<double>;
-using Segment3d = std::pair<maliput::math::Vector3, maliput::math::Vector3>;
-using Segment2d = std::pair<maliput::math::Vector2, maliput::math::Vector2>;
+using Segment3d = std::pair<Vector3, Vector3>;
+using Segment2d = std::pair<Vector2, Vector2>;
+
+static constexpr bool kLeft{true};
+static constexpr bool kRight{false};
 
 namespace {
+
+Vector2 To2D(const Vector3& vector) { return {vector.x(), vector.y()}; }
+
+Segment2d To2D(const Segment3d& segment) { return {To2D(segment.first), To2D(segment.second)}; }
 
 // Determines whether two line segments intersects.
 //
 // Based on https://en.wikipedia.org/wiki/Line%E2%80%93line_intersection#Given_two_points_on_each_line_segment
 bool SegmentsIntersect2d(const Segment2d& lhs, const Segment2d& rhs) {
-  const auto& x1 = lhs.first[0];
-  const auto& y1 = lhs.first[1];
-  const auto& x2 = lhs.second[0];
-  const auto& y2 = lhs.second[1];
-  const auto& x3 = rhs.first[0];
-  const auto& y3 = rhs.first[1];
-  const auto& x4 = rhs.second[0];
-  const auto& y4 = rhs.second[1];
-  const double den = (x1 - x2) * (y3 - y4) - (y1 - y2) * (x3 - x4);
+  const auto& s1_xa = lhs.first[0];
+  const auto& s1_ya = lhs.first[1];
+  const auto& s1_xb = lhs.second[0];
+  const auto& s1_yb = lhs.second[1];
+  const auto& s2_xa = rhs.first[0];
+  const auto& s2_ya = rhs.first[1];
+  const auto& s2_xb = rhs.second[0];
+  const auto& s2_yb = rhs.second[1];
+  const double den = (s1_xa - s1_xb) * (s2_ya - s2_yb) - (s1_ya - s1_yb) * (s2_xa - s2_xb);
   if (den == 0) {
     // They are parallel or coincident.
     return false;
   }
-  const double t_num = (x1 - x3) * (y3 - y4) - (y1 - y3) * (x3 - x4);
-  const double u_num = (x1 - x3) * (y1 - y2) - (y1 - y3) * (x1 - x2);
+  const double t_num = (s1_xa - s2_xa) * (s2_ya - s2_yb) - (s1_ya - s2_ya) * (s2_xa - s2_xb);
+  const double u_num = (s1_xa - s2_xa) * (s1_ya - s1_yb) - (s1_ya - s2_ya) * (s1_xa - s1_xb);
   const double t = t_num / den;
   const double u = u_num / den;
   return (t >= 0 && t <= 1 && u >= 0 && u <= 1);
 }
 
 // Obtains the distance between @p lhs and @p rhs points projected on the xy plane.
-double Distance2d(const maliput::math::Vector3& lhs, const maliput::math::Vector3& rhs) {
-  const maliput::math::Vector2 lhs_2d{lhs.x(), lhs.y()};
-  const maliput::math::Vector2 rhs_2d{rhs.x(), rhs.y()};
-  return (lhs_2d - rhs_2d).norm();
-}
+double Distance2d(const Vector3& lhs, const Vector3& rhs) { return (To2D(lhs) - To2D(rhs)).norm(); }
 
 // Determines whether point @p p is located left from segment compound by @p seg_first and @p seg_second.
-bool PointIsLeftOf(const maliput::math::Vector3& seg_first, const maliput::math::Vector3& seg_second,
-                   const maliput::math::Vector3& p) {
+bool PointIsLeftOf(const Vector3& seg_first, const Vector3& seg_second, const Vector3& p) {
   return ((seg_second - seg_first).cross(p - seg_first)).z() > 0;
 }
 
-maliput::math::Vector3 MakeCenterpoint(const maliput::math::Vector3& p1, const maliput::math::Vector3& p2) {
-  return (p1 + p2) / 2.;
-}
+Vector3 MakeCenterpoint(const Vector3& p1, const Vector3& p2) { return (p1 + p2) / 2.; }
 
 // Helper class for evaluating the boundaries of a lane.
 class BoundChecker {
@@ -120,62 +122,50 @@ class BoundChecker {
 
   bool Intersects2d(const Segment3d& seg) const {
     const Segment2d seg2d{{seg.first.x(), seg.first.y()}, {seg.second.x(), seg.second.y()}};
-    const bool result =
-        IntersectsLeft2d(seg2d) || IntersectsRight2d(seg2d) || CrossesEntry2d(seg2d) || CrossesExit2d(seg2d);
-    return result;
+    return IntersectsLeft2d(seg2d) || IntersectsRight2d(seg2d) || CrossesEntry2d(seg2d) || CrossesExit2d(seg2d);
   }
 
   bool IntersectsLeft2d(const Segment2d& seg) const {
-    for (const auto left_segment : left_segments_) {
-      const Segment2d left_seg{{left_segment.first.x(), left_segment.first.y()},
-                               {left_segment.second.x(), left_segment.second.y()}};
-      if (SegmentsIntersect2d(seg, left_seg)) {
-        if (!(seg.first == left_seg.first)) {
-          return true;
-        }
-      }
-    }
-    return false;
+    const auto it = std::find_if(left_segments_.begin(), left_segments_.end(), [&seg](const Segment3d& left_segment) {
+      const Segment2d left_segment_2d{To2D(left_segment)};
+      return SegmentsIntersect2d(seg, left_segment_2d) ? !(seg.first == left_segment_2d.first) : false;
+    });
+    return it != left_segments_.end();
   }
 
   bool IntersectsRight2d(const Segment2d& seg) const {
-    for (const auto right_segment : right_segments_) {
-      const Segment2d right_seg{{right_segment.first.x(), right_segment.first.y()},
-                                {right_segment.second.x(), right_segment.second.y()}};
-      if (SegmentsIntersect2d(right_seg, seg)) {
-        if (!(seg.first == right_seg.first)) {
-          return true;
-        }
-      }
-    }
-    return false;
+    const auto it =
+        std::find_if(right_segments_.begin(), right_segments_.end(), [&seg](const Segment3d& right_segment) {
+          const Segment2d right_segment_2d{To2D(right_segment)};
+          return SegmentsIntersect2d(seg, right_segment_2d) ? !(seg.first == right_segment_2d.first) : false;
+        });
+    return it != right_segments_.end();
   }
 
   bool CrossesEntry2d(const Segment2d& seg) const {
-    const Segment2d entry_2d{{entry_.first.x(), entry_.first.y()}, {entry_.second.x(), entry_.second.y()}};
-    if (SegmentsIntersect2d(seg, entry_2d)) {
-      return PointIsLeftOf({entry_2d.first.x(), entry_2d.first.y(), 0.}, {entry_2d.second.x(), entry_2d.second.y(), 0.},
-                           {seg.second.x(), seg.second.y(), 0.});
-    }
-    return false;
+    const Segment2d entry_2d{To2D(entry_)};
+    return SegmentsIntersect2d(seg, entry_2d)
+               ? PointIsLeftOf({entry_2d.first.x(), entry_2d.first.y(), 0.},
+                               {entry_2d.second.x(), entry_2d.second.y(), 0.}, {seg.second.x(), seg.second.y(), 0.})
+               : false;
   }
 
   bool CrossesExit2d(const Segment2d& seg) const {
     const Segment2d exit_2d{{exit_.first.x(), exit_.first.y()}, {exit_.second.x(), exit_.second.y()}};
-    if (SegmentsIntersect2d(seg, exit_2d)) {
-      PointIsLeftOf({exit_2d.first.x(), exit_2d.first.y(), 0.}, {exit_2d.second.x(), exit_2d.second.y(), 0.},
-                    {seg.second.x(), seg.second.y(), 0.});
-    }
-    return false;
+    return SegmentsIntersect2d(seg, exit_2d)
+               ? PointIsLeftOf({exit_2d.first.x(), exit_2d.first.y(), 0.}, {exit_2d.second.x(), exit_2d.second.y(), 0.},
+                               {seg.second.x(), seg.second.y(), 0.})
+               : false;
   }
 
   template <typename Func>
-  void ForEachPointLeftUntil(LineString3d::const_iterator iter, Func&& f) const {
-    return ForEachPointUntilImpl(iter, left_, std::forward<Func>(f));
-  }
-  template <typename Func>
-  void ForEachPointRightUntil(LineString3d::const_iterator iter, Func&& f) const {
-    return ForEachPointUntilImpl(iter, right_, std::forward<Func>(f));
+  void ForEachPointUntil(bool is_left, LineString3d::const_iterator iter, Func&& f) const {
+    const LineString3d& points = is_left ? left_ : right_;
+    for (auto iter = points.begin(); iter != points.end(); ++iter) {
+      if (f(iter)) {
+        break;
+      }
+    }
   }
 
  private:
@@ -188,15 +178,6 @@ class BoundChecker {
     return segments;
   }
 
-  template <typename Func>
-  static void ForEachPointUntilImpl(LineString3d::const_iterator iter, const LineString3d& points, Func&& f) {
-    for (auto iter = points.begin(); iter != points.end(); ++iter) {
-      if (f(iter)) {
-        break;
-      }
-    }
-  }
-
   const LineString3d& left_;
   const LineString3d& right_;
   Segment3d entry_, exit_;
@@ -206,30 +187,30 @@ class BoundChecker {
 
 std::pair<LineString3d::const_iterator, OptDistance> FindClosestNonintersectingPoint(
     LineString3d::const_iterator current_position, LineString3d::const_iterator other_point, const BoundChecker& bounds,
-    const maliput::math::Vector3& last_point, bool is_left) {
+    const Vector3& last_point, bool is_left) {
   OptDistance distance;
   LineString3d::const_iterator closest_position{nullptr};
   double d_last_other = (*other_point - last_point).norm();
 
   auto non_intersecting_point_loop = [&](LineString3d::const_iterator candidate) {
-    // point must be after current_position
+    // Point must be after current_position.
     if (candidate < current_position) {
       return false;
     }
-    const auto candidate_distance = Distance2d(*candidate, *other_point) / 2;  // candidate distance
-    // we use the triangle inequation to find a distance where we can not
+    const double candidate_distance = Distance2d(*candidate, *other_point) / 2.;  // candidate distance
+    // We use the triangle inequation to find a distance where we cannot
     // expect a closer point than the current one.
-    if (!!distance && candidate_distance / 2 - d_last_other > *distance) {
-      return true;  // stops the loop
+    if (!!distance && candidate_distance / 2. - d_last_other > *distance) {
+      return true;  //> Stops the loop.
     }
     if (!!distance && *distance <= candidate_distance) {
       return false;
     }
-    // Candidates are only valid candidates if
-    // 1. their distance is minimal (at least for now) -> checked above
-    // 2. the new connection does not intersect with the borders
-    // 3. connection between point on one bound and point on other bound
-    // does not intersect with other parts of the boundary
+    // Candidates are only valid candidates when:
+    // 1. Their distance is minimal (at least for now). -> checked above
+    // 2. The new connection does not intersect with the borders.
+    // 3. Connection between point on one bound and point on other bound
+    // does not intersect with other parts of the boundary.
     const Segment3d bound_connection(*other_point, *candidate);
     const auto centerline_point_candidate = MakeCenterpoint(bound_connection.first, bound_connection.second);
     const Segment3d centerline_candidate{last_point, centerline_point_candidate};
@@ -239,21 +220,16 @@ std::pair<LineString3d::const_iterator, OptDistance> FindClosestNonintersectingP
     }
     return false;
   };
-  if (is_left) {
-    bounds.ForEachPointLeftUntil(other_point,
-                                 non_intersecting_point_loop);  // For each point in the left string to other_point
-  } else {
-    bounds.ForEachPointRightUntil(other_point, non_intersecting_point_loop);
-  }
+  bounds.ForEachPointUntil(is_left, other_point, non_intersecting_point_loop);
   return {closest_position, distance};
 }
 
 }  // namespace
 
 LineString3d ComputeCenterline3d(const LineString3d& left, const LineString3d& right) {
-  LineString3d centerline;
+  std::vector<Vector3> centerline;
   BoundChecker bounds(left, right);
-  // Initial point
+  // Initial point.
   centerline.push_back(MakeCenterpoint(left.first(), right.first()));
 
   auto left_current = left.begin();
@@ -265,19 +241,19 @@ LineString3d ComputeCenterline3d(const LineString3d& left, const LineString3d& r
 
     LineString3d::const_iterator left_candidate;
     LineString3d::const_iterator right_candidate;
-    // Determine left candidate
+    // Determine left candidate.
     std::tie(left_candidate, left_candidate_distance) =
-        FindClosestNonintersectingPoint(std::next(left_current), right_current, bounds, centerline.last(), true);
+        FindClosestNonintersectingPoint(std::next(left_current), right_current, bounds, centerline.back(), kLeft);
 
-    // Determine right candidate
+    // Determine right candidate.
     std::tie(right_candidate, right_candidate_distance) =
-        FindClosestNonintersectingPoint(std::next(right_current), left_current, bounds, centerline.last(), false);
-    // Choose the better one
+        FindClosestNonintersectingPoint(std::next(right_current), left_current, bounds, centerline.back(), kRight);
+    // Choose the better one.
     if (left_candidate_distance && (!right_candidate_distance || left_candidate_distance <= right_candidate_distance)) {
       MALIPUT_THROW_UNLESS(left_candidate != left.end());
 
-      const auto& left_point = left[size_t(left_candidate - left.begin())];
-      const auto& right_point = right[size_t(right_current - right.begin())];
+      const auto& left_point = left[static_cast<size_t>(left_candidate - left.begin())];
+      const auto& right_point = right[static_cast<size_t>(right_current - right.begin())];
       const auto centerpoint = MakeCenterpoint(left_point, right_point);
       centerline.push_back(centerpoint);
       left_current = left_candidate;
@@ -285,22 +261,22 @@ LineString3d ComputeCenterline3d(const LineString3d& left, const LineString3d& r
                (!left_candidate_distance || left_candidate_distance > right_candidate_distance)) {
       MALIPUT_THROW_UNLESS(right_candidate != right.end());
 
-      const auto& left_point = left[size_t(left_current - left.begin())];
-      const auto& right_point = right[size_t(right_candidate - right.begin())];
+      const auto& left_point = left[static_cast<size_t>(left_current - left.begin())];
+      const auto& right_point = right[static_cast<size_t>(right_candidate - right.begin())];
       const auto centerpoint = MakeCenterpoint(left_point, right_point);
       centerline.push_back(centerpoint);
       right_current = right_candidate;
     } else {
-      // no next point found. We are done here
+      // No next point found. We are done here.
       break;
     }
   }
 
-  // we want the centerpoint defined by the endpoints inside in any case
+  // We want the centerpoint defined by the endpoints inside in any case.
   if (!(left_current == std::prev(left.end()) && right_current == std::prev(right.end()))) {
     centerline.push_back(MakeCenterpoint(left.last(), right.last()));
   }
-  return centerline;
+  return LineString3d{centerline};
 }
 
 }  // namespace utility

--- a/test/geometry/CMakeLists.txt
+++ b/test/geometry/CMakeLists.txt
@@ -1,4 +1,5 @@
 ament_add_gtest(line_string_test line_string_test.cc)
+ament_add_gtest(geometry_test utility/geometry_test.cc)
 
 macro(add_dependencies_to_test target)
 if (TARGET ${target})
@@ -14,9 +15,11 @@ if (TARGET ${target})
           maliput::common
           maliput::math
           maliput::test_utilities
+          maliput_sparse::geometry
       )
 
     endif()
 endmacro()
 
 add_dependencies_to_test(line_string_test)
+add_dependencies_to_test(geometry_test)

--- a/test/geometry/line_string_test.cc
+++ b/test/geometry/line_string_test.cc
@@ -61,7 +61,6 @@ class LineString3dTest : public ::testing::Test {
   const Vector3 p3{Vector3::UnitZ()};
 };
 
-TEST_F(LineString3dTest, DefaultConstructor) { const LineString3d dut{}; }
 TEST_F(LineString3dTest, ConstructorWithInitializerListIsSuccessful) { const LineString3d dut{p1, p2, p3}; }
 
 TEST_F(LineString3dTest, ConstructorWithVectorIsSuccessful) {
@@ -74,21 +73,14 @@ TEST_F(LineString3dTest, ConstructorWithIteratorsIsSucceful) {
 }
 
 TEST_F(LineString3dTest, Api) {
-  const double expected_length{2. * std::sqrt(2.)};
-  LineString3d dut(std::vector<Vector3>{p1, p2, p3});
+  const LineString3d dut(std::vector<Vector3>{p1, p2, p3});
   EXPECT_TRUE(p1 == dut.first());
-  EXPECT_TRUE(p1 == *dut.begin());
   EXPECT_TRUE(p3 == dut.last());
-  EXPECT_TRUE(p3 == *(dut.end() - 1));
   EXPECT_TRUE(p1 == dut.at(0));
   EXPECT_TRUE(p2 == dut.at(1));
   EXPECT_TRUE(p3 == dut.at(2));
   EXPECT_EQ(3, dut.size());
-  EXPECT_NEAR(expected_length, dut.length(), kTolerance);
-  dut.push_back(p1);
-  EXPECT_EQ(4, dut.size());
-  EXPECT_TRUE(p1 == dut.at(3));
-  EXPECT_NEAR(expected_length + std::sqrt(2.), dut.length(), kTolerance);
+  EXPECT_NEAR(2. * std::sqrt(2.), dut.length(), kTolerance);
 }
 
 TEST_F(LineString3dTest, LengthInjectedDistanceFunction) {
@@ -115,19 +107,14 @@ TEST_F(LineString2dTest, ConstructorWithIteratorsIsSucceful) {
 }
 
 TEST_F(LineString2dTest, Api) {
-  const double expected_length{1. + std::sqrt(2.)};
-  LineString2d dut(std::vector<Vector2>{p1, p2, p3});
+  const LineString2d dut(std::vector<Vector2>{p1, p2, p3});
   EXPECT_TRUE(p1 == dut.first());
   EXPECT_TRUE(p3 == dut.last());
   EXPECT_TRUE(p1 == dut.at(0));
   EXPECT_TRUE(p2 == dut.at(1));
   EXPECT_TRUE(p3 == dut.at(2));
   EXPECT_EQ(3, dut.size());
-  EXPECT_NEAR(expected_length, dut.length(), kTolerance);
-  dut.push_back(p1);
-  EXPECT_EQ(4, dut.size());
-  EXPECT_TRUE(p1 == dut.at(3));
-  EXPECT_NEAR(expected_length + 1., dut.length(), kTolerance);
+  EXPECT_NEAR(1. + std::sqrt(2.), dut.length(), kTolerance);
 }
 
 TEST_F(LineString2dTest, LengthWithInjectedDistanceFunction) {

--- a/test/geometry/line_string_test.cc
+++ b/test/geometry/line_string_test.cc
@@ -79,7 +79,7 @@ TEST_F(LineString3dTest, Api) {
   EXPECT_TRUE(p1 == dut.at(0));
   EXPECT_TRUE(p2 == dut.at(1));
   EXPECT_TRUE(p3 == dut.at(2));
-  EXPECT_EQ(3, dut.size());
+  EXPECT_EQ(static_cast<size_t>(3), dut.size());
   EXPECT_NEAR(2. * std::sqrt(2.), dut.length(), kTolerance);
 }
 
@@ -113,7 +113,7 @@ TEST_F(LineString2dTest, Api) {
   EXPECT_TRUE(p1 == dut.at(0));
   EXPECT_TRUE(p2 == dut.at(1));
   EXPECT_TRUE(p3 == dut.at(2));
-  EXPECT_EQ(3, dut.size());
+  EXPECT_EQ(static_cast<size_t>(3), dut.size());
   EXPECT_NEAR(1. + std::sqrt(2.), dut.length(), kTolerance);
 }
 

--- a/test/geometry/line_string_test.cc
+++ b/test/geometry/line_string_test.cc
@@ -61,6 +61,7 @@ class LineString3dTest : public ::testing::Test {
   const Vector3 p3{Vector3::UnitZ()};
 };
 
+TEST_F(LineString3dTest, DefaultConstructor) { const LineString3d dut{}; }
 TEST_F(LineString3dTest, ConstructorWithInitializerListIsSuccessful) { const LineString3d dut{p1, p2, p3}; }
 
 TEST_F(LineString3dTest, ConstructorWithVectorIsSuccessful) {
@@ -73,14 +74,21 @@ TEST_F(LineString3dTest, ConstructorWithIteratorsIsSucceful) {
 }
 
 TEST_F(LineString3dTest, Api) {
-  const LineString3d dut(std::vector<Vector3>{p1, p2, p3});
+  const double expected_length{2. * std::sqrt(2.)};
+  LineString3d dut(std::vector<Vector3>{p1, p2, p3});
   EXPECT_TRUE(p1 == dut.first());
+  EXPECT_TRUE(p1 == *dut.begin());
   EXPECT_TRUE(p3 == dut.last());
+  EXPECT_TRUE(p3 == *(dut.end() - 1));
   EXPECT_TRUE(p1 == dut.at(0));
   EXPECT_TRUE(p2 == dut.at(1));
   EXPECT_TRUE(p3 == dut.at(2));
   EXPECT_EQ(3, dut.size());
-  EXPECT_NEAR(2. * std::sqrt(2.), dut.length(), kTolerance);
+  EXPECT_NEAR(expected_length, dut.length(), kTolerance);
+  dut.push_back(p1);
+  EXPECT_EQ(4, dut.size());
+  EXPECT_TRUE(p1 == dut.at(3));
+  EXPECT_NEAR(expected_length + std::sqrt(2.), dut.length(), kTolerance);
 }
 
 TEST_F(LineString3dTest, LengthInjectedDistanceFunction) {
@@ -107,14 +115,19 @@ TEST_F(LineString2dTest, ConstructorWithIteratorsIsSucceful) {
 }
 
 TEST_F(LineString2dTest, Api) {
-  const LineString2d dut(std::vector<Vector2>{p1, p2, p3});
+  const double expected_length{1. + std::sqrt(2.)};
+  LineString2d dut(std::vector<Vector2>{p1, p2, p3});
   EXPECT_TRUE(p1 == dut.first());
   EXPECT_TRUE(p3 == dut.last());
   EXPECT_TRUE(p1 == dut.at(0));
   EXPECT_TRUE(p2 == dut.at(1));
   EXPECT_TRUE(p3 == dut.at(2));
   EXPECT_EQ(3, dut.size());
-  EXPECT_NEAR(1. + std::sqrt(2.), dut.length(), kTolerance);
+  EXPECT_NEAR(expected_length, dut.length(), kTolerance);
+  dut.push_back(p1);
+  EXPECT_EQ(4, dut.size());
+  EXPECT_TRUE(p1 == dut.at(3));
+  EXPECT_NEAR(expected_length + 1., dut.length(), kTolerance);
 }
 
 TEST_F(LineString2dTest, LengthWithInjectedDistanceFunction) {

--- a/test/geometry/utility/geometry_test.cc
+++ b/test/geometry/utility/geometry_test.cc
@@ -77,39 +77,89 @@ std::vector<LeftRightCenterlineCase> LeftRightCenterlineTestCases() {
           LineString3d{{0., -1., 10.}, {10., -1., 10.}, {20., -1., 10.}} /*right*/,
           LineString3d{{0., 0., 5.}, {5., 0., 5.}, {10., 0., 5.}, {15., 0., 5.}, {20., 0., 5.}} /*centerline*/
       },
-      // Variable width. Right lane opens.
-      // {
-      //     LineString3d{{0., 2., 0.}, {1., 2., 0.}, {2., 2., 0.}, {3., 2., 0.}, {4., 2., 0.}} /* left */,
-      //     LineString3d{{0., -2., 0.}, {1., -2., 0.}, {2., -4., 0.}, {3., -4., 0.}, {4., -4., 0.}} /* right */,
-      //     LineString3d{{0., 0., 0.},
-      //                  {0.5, 0., 0.},
-      //                  {1., 0., 0.},
-      //                  {1.5, 0., 0.},
-      //                  {2., 0., 0.},
-      //                  {2.5, 0., 0.},
-      //                  {4., -1., 0.}} /* centerline */,
-      // },
-      // Variable width. Right lane closes.
-      // {
-      //   LineString3d{{0., 4., 0.}, {10., 4., 0.}, {20., 4., 0.}, {30., 4., 0.}, {40., 4., 0.}, {50., 4., 0.}} /* left
-      //   */, LineString3d{{0., -4., 10.}, {10., -4., 10.}, {20., -0., 10.}, {30., -0., 10.}, {40., -4., 10.}, {50.,
-      //   -4., 10.}} /* right */, LineString3d{{0., 0., 5.}, {5., 0., 5.}, {10., 0., 5.}, {15., 2., 5.}, {20., 2., 5.},
-      //   {25., 2., 5.}, {30., 2., 5.}, {35., 2., 5.}, {40., 0., 5.}, {45., 0., 5.}, {50., 0., 5.}} /* centerline */,
-      // },
+      // Straight varying elevation lines in right.
+      {
+          LineString3d{{0., 1., 0.}, {10., 1., 0.}, {20., 1., 0.}} /* left */,
+          LineString3d{{0., -1., 12.}, {10., -1., 14.}, {20., -1., 16.}} /*right*/,
+          LineString3d{{0., 0., 6.}, {5., 0., 6.}, {10., 0., 7.}, {15., 0., 7.}, {20., 0., 8.}} /*centerline*/
+      },
+      // Straight varying elevation lines in both line strings.
+      {
+          LineString3d{{0., 1., 0.}, {10., 1., -2.}, {20., 1., -4.}} /* left */,
+          LineString3d{{0., -1., 12.}, {10., -1., 14.}, {20., -1., 16.}} /*right*/,
+          LineString3d{{0., 0., 6.}, {5., 0., 5.}, {10., 0., 6.}, {15., 0., 5.}, {20., 0., 6.}} /*centerline*/
+      },
+      // Variable width. Right line opens.
+      {
+          LineString3d{{0., 2., 0.}, {1., 2., 0.}, {2., 2., 0.}, {3., 2., 0.}, {4., 2., 0.}} /* left */,
+          LineString3d{{0., -2., 0.}, {1., -2., 0.}, {2., -4., 0.}, {3., -4., 0.}, {4., -4., 0.}} /* right */,
+          LineString3d{{0., 0., 0.},
+                       {0.5, 0., 0.},
+                       {1., 0., 0.},
+                       {1.5, 0., 0.},
+                       {2., 0., 0.},
+                       {2.5, 0., 0.},
+                       {4., -1., 0.}} /* centerline */,
+      },
+      // Variable width. Right line closes.
+      {
+          LineString3d{{0., 4., 0.}, {10., 4., 0.}, {20., 4., 0.}, {30., 4., 0.}, {40., 4., 0.}, {50., 4., 0.}} /* left
+                                                                                                                 */
+          ,
+          LineString3d{{0., -4., 10.},
+                       {10., -4., 10.},
+                       {20., -0., 10.},
+                       {30., -0., 10.},
+                       {40., -4., 10.},
+                       {50., -4., 10.}} /* right */,
+          LineString3d{{0., 0., 5.},
+                       {5., 0., 5.},
+                       {10., 0., 5.},
+                       {15., 2., 5.},
+                       {20., 2., 5.},
+                       {25., 2., 5.},
+                       {30., 2., 5.},
+                       {35., 2., 5.},
+                       {40., 0., 5.},
+                       {45., 0., 5.},
+                       {50., 0., 5.}} /* centerline */,
+      },
       // Starting at different point
-      // {
-      //   LineString3d{{0.5, 2, 0}, {1.5, 2, 0}, {2.5, 2, 0}, {3.5, 2, 0}} /* left */,
-      //   LineString3d{{0, -2, 0}, {1, -2, 0}, {2, -2, 0}, {3, -2, 0}} /* right */,
-      //   LineString3d{{0.25, 0 , 0},{0.75, 0 , 0},{1.25, 0 , 0},{1.75, 0 , 0},{2.25, 0 , 0},{2.75, 0 , 0},{3.25, 0 ,
-      //   0}} /* centerline */,
-      // },
+      {
+          LineString3d{{0.5, 2., 0}, {1.5, 2., 0}, {2.5, 2., 0}, {3.5, 2., 0}} /* left */,
+          LineString3d{{0., -2., 0}, {1, -2., 0}, {2., -2., 0}, {3, -2., 0}} /* right */,
+          LineString3d{{0.25, 0, 0},
+                       {0.75, 0, 0},
+                       {1.25, 0, 0},
+                       {1.75, 0, 0},
+                       {2.25, 0, 0},
+                       {2.75, 0, 0},
+                       {3.25, 0, 0}} /* centerline */,
+      },
       // Starting different point elevated lines.
-      // {
-      //   LineString3d{{0.5, 2, 0}, {1.5, 2, 0}, {2.5, 2, 0}, {3.5, 2, 0}} /* left */,
-      //   LineString3d{{0, -2, 10}, {1, -2, 12}, {2, -2, 14}, {3, -2, 16}} /* right */,
-      //   LineString3d{{0.25, 0 , 5},{0.75, 0 , 6},{1.25, 0 , 6},{1.75, 0 , 7},{2.25, 0 , 7},{2.75, 0 , 8},{3.25, 0 ,
-      //   8}} /* centerline */,
-      // },
+      {
+          LineString3d{{0.5, 2., 0}, {1.5, 2., 0}, {2.5, 2., 0}, {3.5, 2., 0}} /* left */,
+          LineString3d{{0., -2., 10}, {1, -2., 12}, {2., -2., 14}, {3, -2., 16}} /* right */,
+          LineString3d{{0.25, 0, 5},
+                       {0.75, 0, 6},
+                       {1.25, 0, 6},
+                       {1.75, 0, 7},
+                       {2.25, 0, 7},
+                       {2.75, 0, 8},
+                       {3.25, 0, 8}} /* centerline */,
+      },
+      // Starting different point varying elevation of lines.
+      {
+          LineString3d{{0.5, 2., -3.}, {1.5, 2., -5}, {2.5, 2., -2}, {3.5, 2., -7}} /* left */,
+          LineString3d{{0., -2., 10}, {1, -2., 12}, {2., -2., 14}, {3, -2., 16}} /* right */,
+          LineString3d{{0.25, 0, 3.5},
+                       {0.75, 0, 4.5},
+                       {1.25, 0, 3.5},
+                       {1.75, 0, 4.5},
+                       {2.25, 0, 6.},
+                       {2.75, 0, 7.},
+                       {3.25, 0, 4.5}} /* centerline */,
+      },
   };
 }
 
@@ -120,9 +170,6 @@ class ComputeCenterlineTest : public ::testing::TestWithParam<LeftRightCenterlin
 
 TEST_P(ComputeCenterlineTest, Test) {
   const auto dut = ComputeCenterline3d(left_right_centerline_.left, left_right_centerline_.right);
-  for (const auto d : dut) {
-    std::cout << d << std::endl;
-  }
   EXPECT_EQ(left_right_centerline_.expected_centerline.size(), dut.size());
   EXPECT_EQ(left_right_centerline_.expected_centerline, dut);
 }

--- a/test/geometry/utility/geometry_test.cc
+++ b/test/geometry/utility/geometry_test.cc
@@ -1,0 +1,137 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "maliput_sample/geometry/utility/geometry.h"
+
+#include <array>
+#include <cmath>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <maliput/common/assertion_error.h>
+#include <maliput/math/vector.h>
+
+namespace maliput_sample {
+namespace geometry {
+namespace utility {
+namespace test {
+namespace {
+
+using maliput::math::Vector3;
+
+struct LeftRightCenterlineCase {
+  LineString3d left{};
+  LineString3d right{};
+  LineString3d expected_centerline{};
+};
+
+std::vector<LeftRightCenterlineCase> LeftRightCenterlineTestCases() {
+  LineString3d{{0., 1, 0.}, {10., 1., 0.}, {20., 1., 0.}};
+  return {
+      // Straight 2 point lines.
+      {
+          LineString3d{{0., 1., 0.}, {10., 1., 0.}} /* left */, LineString3d{{0., -1., 0.}, {10., -1., 0.}} /*right*/,
+          LineString3d{{0., 0., 0.}, {5., 0., 0.}, {10., 0., 0.}} /*centerline*/
+      },
+      // Straight 3 point lines.
+      {
+          LineString3d{{0., 1., 0.}, {10., 1., 0.}, {20., 1., 0.}} /* left */,
+          LineString3d{{0., -1., 0.}, {10., -1., 0.}, {20., -1., 0.}} /*right*/,
+          LineString3d{{0., 0., 0.}, {5., 0., 0.}, {10., 0., 0.}, {15., 0., 0.}, {20., 0., 0.}} /*centerline*/
+      },
+      // Straight elevated lines.
+      {
+          LineString3d{{0., 1., 10.}, {10., 1., 10.}, {20., 1., 10.}} /* left */,
+          LineString3d{{0., -1., 10.}, {10., -1., 10.}, {20., -1., 10.}} /*right*/,
+          LineString3d{{0., 0., 10.}, {5., 0., 10.}, {10., 0., 10.}, {15., 0., 10.}, {20., 0., 10.}} /*centerline*/
+      },
+      // Straight different elevation lines.
+      {
+          LineString3d{{0., 1., 0.}, {10., 1., 0.}, {20., 1., 0.}} /* left */,
+          LineString3d{{0., -1., 10.}, {10., -1., 10.}, {20., -1., 10.}} /*right*/,
+          LineString3d{{0., 0., 5.}, {5., 0., 5.}, {10., 0., 5.}, {15., 0., 5.}, {20., 0., 5.}} /*centerline*/
+      },
+      // Variable width. Right lane opens.
+      // {
+      //     LineString3d{{0., 2., 0.}, {1., 2., 0.}, {2., 2., 0.}, {3., 2., 0.}, {4., 2., 0.}} /* left */,
+      //     LineString3d{{0., -2., 0.}, {1., -2., 0.}, {2., -4., 0.}, {3., -4., 0.}, {4., -4., 0.}} /* right */,
+      //     LineString3d{{0., 0., 0.},
+      //                  {0.5, 0., 0.},
+      //                  {1., 0., 0.},
+      //                  {1.5, 0., 0.},
+      //                  {2., 0., 0.},
+      //                  {2.5, 0., 0.},
+      //                  {4., -1., 0.}} /* centerline */,
+      // },
+      // Variable width. Right lane closes.
+      // {
+      //   LineString3d{{0., 4., 0.}, {10., 4., 0.}, {20., 4., 0.}, {30., 4., 0.}, {40., 4., 0.}, {50., 4., 0.}} /* left
+      //   */, LineString3d{{0., -4., 10.}, {10., -4., 10.}, {20., -0., 10.}, {30., -0., 10.}, {40., -4., 10.}, {50.,
+      //   -4., 10.}} /* right */, LineString3d{{0., 0., 5.}, {5., 0., 5.}, {10., 0., 5.}, {15., 2., 5.}, {20., 2., 5.},
+      //   {25., 2., 5.}, {30., 2., 5.}, {35., 2., 5.}, {40., 0., 5.}, {45., 0., 5.}, {50., 0., 5.}} /* centerline */,
+      // },
+      // Starting at different point
+      // {
+      //   LineString3d{{0.5, 2, 0}, {1.5, 2, 0}, {2.5, 2, 0}, {3.5, 2, 0}} /* left */,
+      //   LineString3d{{0, -2, 0}, {1, -2, 0}, {2, -2, 0}, {3, -2, 0}} /* right */,
+      //   LineString3d{{0.25, 0 , 0},{0.75, 0 , 0},{1.25, 0 , 0},{1.75, 0 , 0},{2.25, 0 , 0},{2.75, 0 , 0},{3.25, 0 ,
+      //   0}} /* centerline */,
+      // },
+      // Starting different point elevated lines.
+      // {
+      //   LineString3d{{0.5, 2, 0}, {1.5, 2, 0}, {2.5, 2, 0}, {3.5, 2, 0}} /* left */,
+      //   LineString3d{{0, -2, 10}, {1, -2, 12}, {2, -2, 14}, {3, -2, 16}} /* right */,
+      //   LineString3d{{0.25, 0 , 5},{0.75, 0 , 6},{1.25, 0 , 6},{1.75, 0 , 7},{2.25, 0 , 7},{2.75, 0 , 8},{3.25, 0 ,
+      //   8}} /* centerline */,
+      // },
+  };
+}
+
+class ComputeCenterlineTest : public ::testing::TestWithParam<LeftRightCenterlineCase> {
+ public:
+  LeftRightCenterlineCase left_right_centerline_ = GetParam();
+};
+
+TEST_P(ComputeCenterlineTest, Test) {
+  const auto dut = ComputeCenterline3d(left_right_centerline_.left, left_right_centerline_.right);
+  for (const auto d : dut) {
+    std::cout << d << std::endl;
+  }
+  EXPECT_EQ(left_right_centerline_.expected_centerline.size(), dut.size());
+  EXPECT_EQ(left_right_centerline_.expected_centerline, dut);
+}
+
+INSTANTIATE_TEST_CASE_P(ComputeCenterlineTestGroup, ComputeCenterlineTest,
+                        ::testing::ValuesIn(LeftRightCenterlineTestCases()));
+
+}  // namespace
+}  // namespace test
+}  // namespace utility
+}  // namespace geometry
+}  // namespace maliput_sample

--- a/tools/reformat_code.sh
+++ b/tools/reformat_code.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# BSD 3-Clause License
+#
+# Copyright (c) 2022, Woven Planet. All rights reserved.
+# Copyright (c) 2019-2022, Toyota Research Institute. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This script runs clang-format and reformats any C++ code in 
+# the package. It expects a .clang-format to exist within the
+# root directory of the project.  To stop a directory from being
+# reformatted, add a blank `AMENT_IGNORE` file to the root of
+# the directory to exclude.
+
+SCRIPT_PATH=$(realpath ${BASH_SOURCE[0]})
+SCRIPT_DIR=$(dirname $SCRIPT_PATH)
+REPO_DIR=$SCRIPT_DIR/..
+
+export PATH=$PATH:/home/$USER/.local/bin
+
+declare -i CLANGFORMATFAILED=0
+
+pushd $REPO_DIR
+ament_clang_format --config=./.clang-format --reformat || CLANGFORMATFAILED=1
+popd
+
+if [ "$CLANGFORMATFAILED" -ne "0" ]; then
+  echo $'\n*** ament_clang_format failed ***'
+  exit 1
+fi


### PR DESCRIPTION
### Summary
Related to https://github.com/maliput/maliput_sparse/issues/7

Adds a method for computing the centerline out of two line strings.

```cpp
LineString3d ComputeCenterline3d(const LineString3d& left, const LineString3d& right);
```

This method will be used by the LaneGeometry class. This PR is related to https://github.com/maliput/maliput_sparse/pull/8
as they will rely on this method. 

### Pendings
 - [x] Ensure behavior by adding more test cases.
 - [x] Improve documentation.
