### PR TITLE
Rename maliput_sample folder to maliput_sparse.

### DIFF
--- a/include/maliput_sparse/geometry/line_string.h
+++ b/include/maliput_sparse/geometry/line_string.h
@@ -37,7 +37,7 @@
 #include <maliput/common/maliput_throw.h>
 #include <maliput/math/vector.h>
 
-namespace maliput_sample {
+namespace maliput_sparse {
 namespace geometry {
 namespace details {
 
@@ -157,4 +157,4 @@ using LineString2d = LineString<maliput::math::Vector2>;
 using LineString3d = LineString<maliput::math::Vector3>;
 
 }  // namespace geometry
-}  // namespace maliput_sample
+}  // namespace maliput_sparse

--- a/include/maliput_sparse/geometry/utility/geometry.h
+++ b/include/maliput_sparse/geometry/utility/geometry.h
@@ -31,9 +31,9 @@
 
 #include <optional>
 
-#include "maliput_sample/geometry/line_string.h"
+#include "maliput_sparse/geometry/line_string.h"
 
-namespace maliput_sample {
+namespace maliput_sparse {
 namespace geometry {
 namespace utility {
 
@@ -48,4 +48,4 @@ LineString3d ComputeCenterline3d(const LineString3d& left, const LineString3d& r
 
 }  // namespace utility
 }  // namespace geometry
-}  // namespace maliput_sample
+}  // namespace maliput_sparse

--- a/src/geometry/line_string.cc
+++ b/src/geometry/line_string.cc
@@ -27,13 +27,13 @@
 // CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#include "maliput_sample/geometry/line_string.h"
+#include "maliput_sparse/geometry/line_string.h"
 
-namespace maliput_sample {
+namespace maliput_sparse {
 namespace geometry {
 
 template class LineString<maliput::math::Vector2>;
 template class LineString<maliput::math::Vector3>;
 
 }  // namespace geometry
-}  // namespace maliput_sample
+}  // namespace maliput_sparse

--- a/src/geometry/utility/geometry.cc
+++ b/src/geometry/utility/geometry.cc
@@ -56,9 +56,9 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "maliput_sample/geometry/utility/geometry.h"
+#include "maliput_sparse/geometry/utility/geometry.h"
 
-namespace maliput_sample {
+namespace maliput_sparse {
 namespace geometry {
 namespace utility {
 
@@ -274,4 +274,4 @@ LineString3d ComputeCenterline3d(const LineString3d& left, const LineString3d& r
 
 }  // namespace utility
 }  // namespace geometry
-}  // namespace maliput_sample
+}  // namespace maliput_sparse

--- a/test/geometry/line_string_test.cc
+++ b/test/geometry/line_string_test.cc
@@ -27,7 +27,7 @@
 // CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#include "maliput_sample/geometry/line_string.h"
+#include "maliput_sparse/geometry/line_string.h"
 
 #include <array>
 #include <cmath>
@@ -37,7 +37,7 @@
 #include <maliput/common/assertion_error.h>
 #include <maliput/math/vector.h>
 
-namespace maliput_sample {
+namespace maliput_sparse {
 namespace geometry {
 namespace test {
 namespace {
@@ -125,4 +125,4 @@ TEST_F(LineString2dTest, LengthWithInjectedDistanceFunction) {
 }  // namespace
 }  // namespace test
 }  // namespace geometry
-}  // namespace maliput_sample
+}  // namespace maliput_sparse

--- a/test/geometry/utility/geometry_test.cc
+++ b/test/geometry/utility/geometry_test.cc
@@ -27,7 +27,7 @@
 // CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#include "maliput_sample/geometry/utility/geometry.h"
+#include "maliput_sparse/geometry/utility/geometry.h"
 
 #include <array>
 #include <cmath>
@@ -37,7 +37,7 @@
 #include <maliput/common/assertion_error.h>
 #include <maliput/math/vector.h>
 
-namespace maliput_sample {
+namespace maliput_sparse {
 namespace geometry {
 namespace utility {
 namespace test {
@@ -181,4 +181,4 @@ INSTANTIATE_TEST_CASE_P(ComputeCenterlineTestGroup, ComputeCenterlineTest,
 }  // namespace test
 }  // namespace utility
 }  // namespace geometry
-}  // namespace maliput_sample
+}  // namespace maliput_sparse


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Rename `maliput_sample` folder to be `maliput_sparse`

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
