### PR TITLE
Implements LaneGeometry::WDot and LaneGeometry::WInverse.

### DIFF
--- a/include/maliput_sparse/geometry/utility/geometry.h
+++ b/include/maliput_sparse/geometry/utility/geometry.h
@@ -45,6 +45,16 @@ struct BoundPointsResult {
   double length;
 };
 
+/// Holds the result of #GetClosestPoint method.
+struct ClosestPointResult {
+  /// P coordinate in the line string matching the closest point.
+  double p;
+  /// Closest point.
+  maliput::math::Vector3 point;
+  /// Distance between the closest point and the given point.
+  double distance;
+};
+
 /// Computes a 3-dimensional centerline out of the @p left and @p right line string.
 ///
 /// Inspired on https://github.com/fzi-forschungszentrum-informatik/Lanelet2/blob/master/lanelet2_core/src/Lanelet.cpp
@@ -95,15 +105,19 @@ maliput::math::Vector2 Get2DTangentAtP(const LineString3d& line_string, double p
 /// @throws maliput::common::assertion_error When `p ∉ [0., line_string.length()]`.
 maliput::math::Vector3 GetTangentAtP(const LineString3d& line_string, double p);
 
-struct ClosestPointResult {
-  double p;
-  maliput::math::Vector3 point;
-  double distance;
-};
-
+/// Gets the closest point in the @p segment to the given @p xyz point.
+/// @param segment Segment to be computed the closest point from.
+/// @param xyz Point to be computed the closest point to.
+/// @return A ClosestPointResult struct containing the closest point, the distance between the closest point and @p xyz
+/// and the p coordinate in the segment matching the closest point.
 ClosestPointResult GetClosestPoint(const std::pair<maliput::math::Vector3, maliput::math::Vector3>& segment,
                                    const maliput::math::Vector3& xyz);
 
+/// Gets the closest point in the @p line_string to the given @p xyz point.
+/// @param segment Segment to be computed the closest point from.
+/// @param xyz Point to be computed the closest point to.
+/// @return A ClosestPointResult struct containing the closest point, the distance between the closest point and @p xyz
+/// and the p coordinate in the LineString3d matching the closest point.
 ClosestPointResult GetClosestPoint(const LineString3d& line_string, const maliput::math::Vector3& xyz);
 
 }  // namespace utility

--- a/include/maliput_sparse/geometry/utility/geometry.h
+++ b/include/maliput_sparse/geometry/utility/geometry.h
@@ -89,6 +89,23 @@ double Get2DHeadingAtP(const LineString3d& line_string, double p);
 /// @throws maliput::common::assertion_error When `p ∉ [0., line_string.length()]`.
 maliput::math::Vector2 Get2DTangentAtP(const LineString3d& line_string, double p);
 
+/// Returns the 3d-tangent of a @p line_string for a given @p p .
+/// @param line_string LineString to be computed the 3d-tangent from.
+/// @param p P parameter at which compute the 3d-tangent.
+/// @throws maliput::common::assertion_error When `p ∉ [0., line_string.length()]`.
+maliput::math::Vector3 GetTangentAtP(const LineString3d& line_string, double p);
+
+struct ClosestPointResult {
+  double p;
+  maliput::math::Vector3 point;
+  double distance;
+};
+
+ClosestPointResult GetClosestPoint(const std::pair<maliput::math::Vector3, maliput::math::Vector3>& segment,
+                                   const maliput::math::Vector3& xyz);
+
+ClosestPointResult GetClosestPoint(const LineString3d& line_string, const maliput::math::Vector3& xyz);
+
 }  // namespace utility
 }  // namespace geometry
 }  // namespace maliput_sparse

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(base)
 add_subdirectory(geometry)

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -1,0 +1,43 @@
+##############################################################################
+# Sources
+##############################################################################
+
+set(BASE_SOURCES
+  lane.cc
+)
+
+add_library(base ${BASE_SOURCES})
+
+add_library(maliput_sparse::base ALIAS base)
+
+set_target_properties(base
+  PROPERTIES
+    OUTPUT_NAME maliput_sparse_base
+)
+
+target_include_directories(base
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:include>)
+
+target_link_libraries(base
+  PUBLIC
+  maliput::api
+  maliput::common
+  maliput::geometry_base
+)
+
+##############################################################################
+# Export
+##############################################################################
+
+include(CMakePackageConfigHelpers)
+
+install(
+  TARGETS base
+  EXPORT ${PROJECT_NAME}-targets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)

--- a/src/base/lane.cc
+++ b/src/base/lane.cc
@@ -1,0 +1,81 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "base/lane.h"
+
+#include <maliput/common/maliput_throw.h>
+
+namespace maliput_sparse {
+
+Lane::Lane(const maliput::api::LaneId& id, const maliput::api::HBounds& elevation_bounds,
+           std::unique_ptr<geometry::LaneGeometry> lane_geometry)
+    : maliput::geometry_base::Lane(id), elevation_bounds_(elevation_bounds), lane_geometry_(std::move(lane_geometry)) {
+  MALIPUT_THROW_UNLESS(lane_geometry_ != nullptr);
+}
+
+double Lane::do_length() const { return lane_geometry_->ArcLength(); }
+
+maliput::api::RBounds Lane::do_lane_bounds(double s) const {
+  // TODO: Implement
+  MALIPUT_THROW_MESSAGE("Not implemented");
+}
+
+maliput::api::RBounds Lane::do_segment_bounds(double s) const {
+  // TODO: Implement
+  MALIPUT_THROW_MESSAGE("Not implemented");
+}
+
+maliput::api::HBounds Lane::do_elevation_bounds(double, double) const { return elevation_bounds_; }
+
+maliput::math::Vector3 Lane::DoToBackendPosition(const maliput::api::LanePosition& lane_pos) const {
+  MALIPUT_THROW_UNLESS(lane_pos.s() >= lane_geometry_->p0());
+  MALIPUT_THROW_UNLESS(lane_pos.s() <= lane_geometry_->p1());
+  return lane_geometry_->W(lane_pos.srh());
+}
+
+void Lane::DoToLanePositionBackend(const maliput::math::Vector3& backend_pos, maliput::api::LanePosition* lane_position,
+                                   maliput::math::Vector3* nearest_backend_pos, double* distance) const {
+  // TODO: Implement
+  MALIPUT_THROW_MESSAGE("Not implemented");
+}
+
+maliput::api::Rotation Lane::DoGetOrientation(const maliput::api::LanePosition& lane_pos) const {
+  MALIPUT_THROW_UNLESS(lane_pos.s() >= lane_geometry_->p0());
+  MALIPUT_THROW_UNLESS(lane_pos.s() <= lane_geometry_->p1());
+  const auto rpy = lane_geometry_->Orientation(lane_pos.srh());
+  return maliput::api::Rotation::FromRpy(rpy.roll_angle(), rpy.pitch_angle(), rpy.yaw_angle());
+}
+
+maliput::api::LanePosition Lane::DoEvalMotionDerivatives(const maliput::api::LanePosition& position,
+                                                         const maliput::api::IsoLaneVelocity& velocity) const {
+  // TODO: Implement
+  MALIPUT_THROW_MESSAGE("Not implemented");
+}
+
+}  // namespace maliput_sparse

--- a/src/base/lane.h
+++ b/src/base/lane.h
@@ -1,0 +1,79 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <memory>
+
+#include <maliput/api/lane_data.h>
+#include <maliput/common/maliput_copyable.h>
+#include <maliput/geometry_base/lane.h>
+#include <maliput/math/vector.h>
+
+#include "geometry/lane_geometry.h"
+
+namespace maliput_sparse {
+
+class Lane : public maliput::geometry_base::Lane {
+ public:
+  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(Lane);
+  /// Constructs a Lane
+  /// @param id The Lane's unique identifier.
+  /// @param elevation_bounds The Lane's elevation bounds.
+  /// @param lane_geometry A LaneGeometry.
+  Lane(const maliput::api::LaneId& id, const maliput::api::HBounds& elevation_bounds,
+       std::unique_ptr<geometry::LaneGeometry> lane_geometry);
+
+  maliput::math::Vector3 ToBackendPosition(const maliput::api::LanePosition& lane_pos) const {
+    return DoToBackendPosition(lane_pos);
+  }
+
+  const geometry::LaneGeometry* lane_geometry() const { return lane_geometry_.get(); }
+
+ private:
+  // maliput::api::Lane private virtual method implementations.
+  //@{
+  double do_length() const override;
+  maliput::api::RBounds do_lane_bounds(double s) const override;
+  maliput::api::RBounds do_segment_bounds(double s) const override;
+  maliput::api::HBounds do_elevation_bounds(double, double) const override;
+
+  maliput::math::Vector3 DoToBackendPosition(const maliput::api::LanePosition& lane_pos) const override;
+  void DoToLanePositionBackend(const maliput::math::Vector3& backend_pos, maliput::api::LanePosition* lane_position,
+                               maliput::math::Vector3* nearest_backend_pos, double* distance) const override;
+  maliput::api::Rotation DoGetOrientation(const maliput::api::LanePosition& lane_pos) const override;
+  maliput::api::LanePosition DoEvalMotionDerivatives(const maliput::api::LanePosition& position,
+                                                     const maliput::api::IsoLaneVelocity& velocity) const override;
+  //@}
+
+  const maliput::api::HBounds elevation_bounds_;
+  std::unique_ptr<geometry::LaneGeometry> lane_geometry_;
+};
+
+}  // namespace maliput_sparse

--- a/src/geometry/lane_geometry.cc
+++ b/src/geometry/lane_geometry.cc
@@ -84,7 +84,7 @@ maliput::math::Vector3 LaneGeometry::WDot(const maliput::math::Vector3& prh) con
   const maliput::math::Matrix3 R = rpy_at_centerline.ToMatrix();
   const maliput::math::Matrix3 dR_dt = rpy_at_centerline.CalcRotationMatrixDt({d_alpha, d_beta, d_gamma});
 
-  // TODO(francocipollone): Compute dr/dp correctly. For convenience it is considered zero.
+  // TODO(francocipollone): Compute dr/dp correctly. We need to account for lane offset derivatives.
   const double r_dot = 0.;
   return WDot(p) + dR_dt * maliput::math::Vector3(0, r, h) + R * maliput::math::Vector3{0., r_dot, 0.};
 }
@@ -108,10 +108,9 @@ maliput::math::Vector3 LaneGeometry::WInverse(const maliput::math::Vector3& xyz)
 
   const maliput::math::Vector3 d_xyz = xyz - closest_centerline_point.point;
 
-  const maliput::math::Vector3 s_hat = utility::GetTangentAtP(centerline_, closest_centerline_point.p);
-  const maliput::math::Vector3 r_hat =
-      Orientation(closest_centerline_point.p).ToMatrix() * maliput::math::Vector3::UnitY();
-  const maliput::math::Vector3 h_hat = s_hat.cross(r_hat);
+  const maliput::math::Matrix3 rotation = Orientation(closest_centerline_point.p).ToMatrix();
+  const maliput::math::Vector3 r_hat = rotation * maliput::math::Vector3::UnitY();
+  const maliput::math::Vector3 h_hat = rotation * maliput::math::Vector3::UnitZ();
 
   const double r = d_xyz.dot(r_hat);
   const double h = d_xyz.dot(h_hat);

--- a/src/geometry/lane_geometry.cc
+++ b/src/geometry/lane_geometry.cc
@@ -55,8 +55,38 @@ maliput::math::Vector3 LaneGeometry::W(const maliput::math::Vector3& prh) const 
   return rpy.ToMatrix() * maliput::math::Vector3(0., prh.y(), prh.z()) + on_centerline_point;
 }
 
+maliput::math::Vector3 LaneGeometry::WDot(double p) const { return utility::GetTangentAtP(centerline_, p); };
+
 maliput::math::Vector3 LaneGeometry::WDot(const maliput::math::Vector3& prh) const {
-  MALIPUT_THROW_MESSAGE("LaneGeometry::WDot is not implemented yet.");
+  // Implementation based on
+  // https://github.com/maliput/maliput_malidrive/blob/2eb648a030fa4439370b6ed757b84cb726459896/src/maliput_malidrive/road_curve/road_curve.cc#L92-L122
+  MALIPUT_THROW_UNLESS(prh.x() >= p0());
+  MALIPUT_THROW_UNLESS(prh.x() <= p1());
+  const double p = prh.x();
+  const double r = prh.y();
+  const double h = prh.z();
+
+  const maliput::math::RollPitchYaw rpy_at_centerline = Orientation(p);
+
+  // Evaluate dα/dp, dβ/dp, dγ/dp...
+
+  // TODO(francocipollone): Once superelevation is computed (roll) d_alpha should be updated to be the derivative of
+  // the superelevation at p
+  const double d_alpha = 0.;
+  // For computing dβ/dp we need the second derivative of the elevation.
+  // As the lane is linearly changing elevation, the second derivative is zero.
+  const double d_beta = 0.;
+  // For computing dγ/dp we need the second derivative of the heading.
+  // As the lane is linearly changing heading, the second derivative is zero.
+  const double d_gamma = 0.;
+
+  // compute rotation matrix at centerline (R) and its time derivative (dR_dt)
+  const maliput::math::Matrix3 R = rpy_at_centerline.ToMatrix();
+  const maliput::math::Matrix3 dR_dt = rpy_at_centerline.CalcRotationMatrixDt({d_alpha, d_beta, d_gamma});
+
+  // TODO(francocipollone): Compute dr/dp correctly. For convenience it is considered zero.
+  const double r_dot = 0.;
+  return WDot(p) + dR_dt * maliput::math::Vector3(0, r, h) + R * maliput::math::Vector3{0., r_dot, 0.};
 }
 
 maliput::math::RollPitchYaw LaneGeometry::Orientation(double p) const {
@@ -68,11 +98,24 @@ maliput::math::RollPitchYaw LaneGeometry::Orientation(double p) const {
 }
 
 maliput::math::RollPitchYaw LaneGeometry::Orientation(const maliput::math::Vector3& prh) const {
-  MALIPUT_THROW_MESSAGE("LaneGeometry::Orientation(prh) is not implemented yet.");
+  // TODO: Take into account r and h displacement.
+  return Orientation(prh.x());
 }
 
 maliput::math::Vector3 LaneGeometry::WInverse(const maliput::math::Vector3& xyz) const {
-  MALIPUT_THROW_MESSAGE("LaneGeometry::WInverse is not implemented yet.");
+  const utility::ClosestPointResult closest_centerline_point = utility::GetClosestPoint(centerline_, xyz);
+  const double p = closest_centerline_point.p;
+
+  const maliput::math::Vector3 d_xyz = xyz - closest_centerline_point.point;
+
+  const maliput::math::Vector3 s_hat = utility::GetTangentAtP(centerline_, closest_centerline_point.p);
+  const maliput::math::Vector3 r_hat =
+      Orientation(closest_centerline_point.p).ToMatrix() * maliput::math::Vector3::UnitY();
+  const maliput::math::Vector3 h_hat = s_hat.cross(r_hat);
+
+  const double r = d_xyz.dot(r_hat);
+  const double h = d_xyz.dot(h_hat);
+  return {p, r, h};
 }
 
 }  // namespace geometry

--- a/src/geometry/lane_geometry.h
+++ b/src/geometry/lane_geometry.h
@@ -89,7 +89,7 @@ class LaneGeometry {
 
   /// Evaluates @f$ W'(p, 0, 0) @f$ with respect to @f$ p @f$.
   ///
-  /// @param prh A vector in the LaneGeometry domain.
+  /// @param p P parameter of the lane.
   /// @return The derivative of @f$ W @f$ with respect to @f$ p @f$ at @p p.
   maliput::math::Vector3 WDot(double p) const;
 
@@ -103,7 +103,7 @@ class LaneGeometry {
   /// Evaluates the orientation in the INERTIAL Frame of the RoadCurve at @p p,
   /// i.e. at @f$ (p, 0, 0) @f$.
   ///
-  /// @param p The GroundCurve parameter.
+  /// @param p P parameter of the lane.
   /// @return The orientation in the INERTIAL Frame of the RoadCurve at @p p.
   maliput::math::RollPitchYaw Orientation(double p) const;
 

--- a/src/geometry/lane_geometry.h
+++ b/src/geometry/lane_geometry.h
@@ -61,6 +61,9 @@ class LaneGeometry {
   double p0() const { return 0.; }
   double p1() const { return centerline_.length(); }
 
+  /// @return The centerline of the lane.
+  const LineString3d& centerline() const { return centerline_; }
+
   /// @return The arc length of the centerline of the lane.
   double ArcLength();
 
@@ -83,6 +86,12 @@ class LaneGeometry {
   /// @param prh A vector in the LaneGeometry domain.
   /// @return The derivative of @f$ W @f$ with respect to @f$ p @f$ at @p prh.
   maliput::math::Vector3 WDot(const maliput::math::Vector3& prh) const;
+
+  /// Evaluates @f$ W'(p, 0, 0) @f$ with respect to @f$ p @f$.
+  ///
+  /// @param prh A vector in the LaneGeometry domain.
+  /// @return The derivative of @f$ W @f$ with respect to @f$ p @f$ at @p p.
+  maliput::math::Vector3 WDot(double p) const;
 
   /// Evaluates the orientation in the INERTIAL Frame of the LaneGeometry at
   /// @p prh.

--- a/src/geometry/utility/geometry.cc
+++ b/src/geometry/utility/geometry.cc
@@ -350,12 +350,10 @@ Vector3 GetTangentAtP(const LineString3d& line_string, double p) {
 ClosestPointResult GetClosestPoint(const Segment3d& segment, const maliput::math::Vector3& xyz) {
   const maliput::math::Vector3 d_segment{segment.second - segment.first};
   const maliput::math::Vector3 d_xyz_to_first{xyz - segment.first};
-  const maliput::math::Vector3 unit_vector{d_segment / d_segment.norm()};
 
-  const double unsaturated_p = d_xyz_to_first.dot(unit_vector);
-
+  const double unsaturated_p = d_xyz_to_first.dot(d_segment.normalized());
   const double p = std::clamp(unsaturated_p, 0., d_segment.norm());
-  const auto point = InterpolatedPointAtP(LineString3d{segment.first, segment.second}, p);
+  const maliput::math::Vector3 point = InterpolatedPointAtP(LineString3d{segment.first, segment.second}, p);
   const double distance = (xyz - point).norm();
   return {p, point, distance};
 }

--- a/src/geometry/utility/geometry.cc
+++ b/src/geometry/utility/geometry.cc
@@ -58,6 +58,7 @@
 
 #include "maliput_sparse/geometry/utility/geometry.h"
 
+#include <algorithm>
 #include <cmath>
 
 namespace maliput_sparse {
@@ -78,6 +79,14 @@ namespace {
 Vector2 To2D(const Vector3& vector) { return {vector.x(), vector.y()}; }
 
 Segment2d To2D(const Segment3d& segment) { return {To2D(segment.first), To2D(segment.second)}; }
+
+LineString2d To2D(const LineString3d& line_string) {
+  std::vector<Vector2> points;
+  for (const auto& point : line_string) {
+    points.push_back(To2D(point));
+  }
+  return LineString2d{points};
+}
 
 // Determines whether two line segments intersects.
 //
@@ -325,8 +334,46 @@ double Get2DHeadingAtP(const LineString3d& line_string, double p) {
 }
 
 Vector2 Get2DTangentAtP(const LineString3d& line_string, double p) {
-  const double heading = Get2DHeadingAtP(line_string, p);
-  return {std::cos(heading), std::sin(heading)};
+  // const double heading = Get2DHeadingAtP(line_string, p);
+  // return {std::cos(heading), std::sin(heading)};
+  const auto line_string_points_length = GetBoundPointsAtP(line_string, p);
+  const Vector2 d_xy{To2D(*line_string_points_length.second) - To2D(*line_string_points_length.first)};
+  return (d_xy / (To2D(line_string).length())).normalized();
+}
+
+Vector3 GetTangentAtP(const LineString3d& line_string, double p) {
+  const auto line_string_points_length = GetBoundPointsAtP(line_string, p);
+  const Vector3 d_xyz{*line_string_points_length.second - *line_string_points_length.first};
+  return (d_xyz / (line_string.length())).normalized();
+}
+
+ClosestPointResult GetClosestPoint(const Segment3d& segment, const maliput::math::Vector3& xyz) {
+  const maliput::math::Vector3 d_segment{segment.second - segment.first};
+  const maliput::math::Vector3 d_xyz_to_first{xyz - segment.first};
+  const maliput::math::Vector3 unit_vector{d_segment / d_segment.norm()};
+
+  const double unsaturated_p = d_xyz_to_first.dot(unit_vector);
+
+  const double p = std::clamp(unsaturated_p, 0., d_segment.norm());
+  const auto point = InterpolatedPointAtP(LineString3d{segment.first, segment.second}, p);
+  const double distance = (xyz - point).norm();
+  return {p, point, distance};
+}
+
+ClosestPointResult GetClosestPoint(const LineString3d& line_string, const maliput::math::Vector3& xyz) {
+  ClosestPointResult result;
+  result.distance = std::numeric_limits<double>::max();
+  double length{};
+  for (auto first = line_string.begin(), second = std::next(line_string.begin()); second != line_string.end();
+       ++first, ++second) {
+    const auto closest_point_res = GetClosestPoint(Segment3d{*first, *second}, xyz);
+    if (closest_point_res.distance < result.distance) {
+      result = closest_point_res;
+      result.p += length;
+    }
+    length += (*second - *first).norm();  //> Adds segment length
+  }
+  return result;
 }
 
 }  // namespace utility

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(ament_cmake_gtest REQUIRED)
 find_package(ament_cmake_gmock REQUIRED)
 
+add_subdirectory(base)
 add_subdirectory(geometry)

--- a/test/base/CMakeLists.txt
+++ b/test/base/CMakeLists.txt
@@ -1,0 +1,25 @@
+ament_add_gtest(lane_test lane_test.cc)
+
+macro(add_dependencies_to_test target)
+if (TARGET ${target})
+
+      target_include_directories(${target}
+        PRIVATE
+          ${CMAKE_CURRENT_SOURCE_DIR}
+          ${PROJECT_SOURCE_DIR}/include
+          ${PROJECT_SOURCE_DIR}/src
+          ${PROJECT_SOURCE_DIR}/test
+      )
+
+      target_link_libraries(${target}
+          maliput::common
+          maliput::math
+          maliput::test_utilities
+          maliput_sparse::base
+          maliput_sparse::geometry
+      )
+
+    endif()
+endmacro()
+
+add_dependencies_to_test(lane_test)

--- a/test/base/lane_test.cc
+++ b/test/base/lane_test.cc
@@ -1,0 +1,132 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet. All rights reserved.
+// Copyright (c) 2022, Toyota Research Institute. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "base/lane.h"
+
+#include <gtest/gtest.h>
+#include <maliput/api/lane.h>
+#include <maliput/api/lane_data.h>
+#include <maliput/common/assertion_error.h>
+#include <maliput/math/vector.h>
+#include <maliput/test_utilities/maliput_math_compare.h>
+
+#include "maliput_sparse/geometry/line_string.h"
+
+namespace maliput_sparse {
+namespace test {
+namespace {
+
+using geometry::LineString3d;
+using maliput::api::InertialPosition;
+using maliput::api::LanePosition;
+using maliput::api::Rotation;
+using maliput::math::Vector2;
+using maliput::math::Vector3;
+
+struct LaneTestCase {
+  LineString3d left{};
+  LineString3d right{};
+  std::vector<LanePosition> srh{};
+  std::vector<InertialPosition> expected_backend_pos{};
+  std::vector<Rotation> expected_rotation{};
+  double expected_length{};
+};
+
+std::vector<LaneTestCase> LaneTestCases() {
+  return {{
+              LineString3d{{0., 2., 0.}, {100., 2., 0.}} /* left*/,
+              LineString3d{{0., -2., 0.}, {100., -2., 0.}} /* right*/,
+              {{0., 0., 0.}} /* srh */,
+              {{0., 0., 0.}} /* expected_backend_pos */,
+              {Rotation::FromRpy(0., 0., 0.)} /* expected_rotation */,
+              100. /* expected_length */
+          },
+          {
+              // Arc-like lane:
+              //    | |  --> no elevation
+              //  __/ /  --> no elevation
+              //  __ /   --> linear elevation
+              LineString3d{{0., 2., 0.}, {100., 2., 100.}, {200., 102., 100.}, {200., 200., 100.}} /* left*/,
+              LineString3d{{0., -2., 0.}, {100., -2., 100.}, {204., 102., 100.}, {204., 200., 100.}} /* right*/,
+              // Centerline : {0., 0., 0.}, {100., 0., 100.}, {202., 102, 100.}, {202., 200., 100.}
+              {
+                  {50. * std::sqrt(2.), 0., 0.},
+                  {50. * std::sqrt(2.), -2., -2.},
+                  {100. * std::sqrt(2.) + 102. * std::sqrt(2.), 0., 0.},
+                  {100. * std::sqrt(2.) + 102. * std::sqrt(2.) + 98., -1., 4.},
+              } /* srh */,
+              {
+                  {50., 0., 50.},
+                  {50. + 2 * std::sqrt(2.) / 2., -2., 50. - 2 * std::sqrt(2.) / 2.},
+                  {202., 102., 100.},
+                  {203., 200., 104.},
+              } /* expected_backend_pos */,
+              {
+                  Rotation::FromRpy(0., -M_PI / 4., 0.),
+                  Rotation::FromRpy(0., -M_PI / 4., 0.),
+                  Rotation::FromRpy(0., 0., M_PI / 4.),
+                  Rotation::FromRpy(0., 0., M_PI / 2.),
+              } /* expected_rotation */,
+              100. * std::sqrt(2.) + 102. * std::sqrt(2.) + 98. /* expected_length */
+          }};
+}
+
+class LaneTest : public ::testing::TestWithParam<LaneTestCase> {
+ public:
+  static constexpr double kTolerance{1.e-5};
+  static constexpr double kScaleLength{1.};
+
+  const maliput::api::LaneId kLaneId{"dut id"};
+  const maliput::api::HBounds kHBounds{0., 5.};
+  LaneTestCase case_ = GetParam();
+  std::unique_ptr<geometry::LaneGeometry> lane_geometry_ =
+      std::make_unique<geometry::LaneGeometry>(case_.left, case_.right, kTolerance, kScaleLength);
+};
+
+TEST_P(LaneTest, Test) {
+  ASSERT_EQ(case_.srh.size(), case_.expected_backend_pos.size()) << ">>>>> Test case is ill-formed.";
+  ASSERT_EQ(case_.srh.size(), case_.expected_rotation.size()) << ">>>>> Test case is ill-formed.";
+  const Lane dut{kLaneId, kHBounds, std::move(lane_geometry_)};
+  EXPECT_DOUBLE_EQ(case_.expected_length, dut.length());
+  for (std::size_t i = 0; i < case_.srh.size(); ++i) {
+    const auto backend_pos = dut.ToBackendPosition(case_.srh[i]);
+    const auto rpy = dut.GetOrientation(case_.srh[i]);
+    EXPECT_TRUE(maliput::math::test::CompareVectors(case_.expected_backend_pos[i].xyz(), backend_pos, kTolerance))
+        << "Expected backend_pos: " << case_.expected_backend_pos[i].xyz() << " vs backend_pos: " << backend_pos;
+    EXPECT_TRUE(
+        maliput::math::test::CompareVectors(case_.expected_rotation[i].rpy().vector(), rpy.rpy().vector(), kTolerance))
+        << "Expected RPY: " << case_.expected_rotation[i].rpy().vector() << " vs RPY: " << rpy.rpy().vector();
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(LaneTestGroup, LaneTest, ::testing::ValuesIn(LaneTestCases()));
+
+}  // namespace
+}  // namespace test
+}  // namespace maliput_sparse


### PR DESCRIPTION
# 🎉 New feature

Part of #7 

## Summary
Provides `WDot` and `WInverse` methods.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

