### PR TITLE
Adds lane class

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(base)
 add_subdirectory(geometry)

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -1,0 +1,43 @@
+##############################################################################
+# Sources
+##############################################################################
+
+set(BASE_SOURCES
+  lane.cc
+)
+
+add_library(base ${BASE_SOURCES})
+
+add_library(maliput_sparse::base ALIAS base)
+
+set_target_properties(base
+  PROPERTIES
+    OUTPUT_NAME maliput_sparse_base
+)
+
+target_include_directories(base
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:include>)
+
+target_link_libraries(base
+  PUBLIC
+  maliput::api
+  maliput::common
+  maliput::geometry_base
+)
+
+##############################################################################
+# Export
+##############################################################################
+
+include(CMakePackageConfigHelpers)
+
+install(
+  TARGETS base
+  EXPORT ${PROJECT_NAME}-targets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)

--- a/src/base/lane.cc
+++ b/src/base/lane.cc
@@ -1,0 +1,81 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "base/lane.h"
+
+#include <maliput/common/maliput_throw.h>
+
+namespace maliput_sparse {
+
+Lane::Lane(const maliput::api::LaneId& id, const maliput::api::HBounds& elevation_bounds,
+           std::unique_ptr<geometry::LaneGeometry> lane_geometry)
+    : maliput::geometry_base::Lane(id), elevation_bounds_(elevation_bounds), lane_geometry_(std::move(lane_geometry)) {
+  MALIPUT_THROW_UNLESS(lane_geometry_ != nullptr);
+}
+
+double Lane::do_length() const { return lane_geometry_->ArcLength(); }
+
+maliput::api::RBounds Lane::do_lane_bounds(double s) const {
+  // TODO: Implement
+  MALIPUT_THROW_MESSAGE("Not implemented");
+}
+
+maliput::api::RBounds Lane::do_segment_bounds(double s) const {
+  // TODO: Implement
+  MALIPUT_THROW_MESSAGE("Not implemented");
+}
+
+maliput::api::HBounds Lane::do_elevation_bounds(double, double) const { return elevation_bounds_; }
+
+maliput::math::Vector3 Lane::DoToBackendPosition(const maliput::api::LanePosition& lane_pos) const {
+  MALIPUT_THROW_UNLESS(lane_pos.s() >= lane_geometry_->p0());
+  MALIPUT_THROW_UNLESS(lane_pos.s() <= lane_geometry_->p1());
+  return lane_geometry_->W(lane_pos.srh());
+}
+
+void Lane::DoToLanePositionBackend(const maliput::math::Vector3& backend_pos, maliput::api::LanePosition* lane_position,
+                                   maliput::math::Vector3* nearest_backend_pos, double* distance) const {
+  // TODO: Implement
+  MALIPUT_THROW_MESSAGE("Not implemented");
+}
+
+maliput::api::Rotation Lane::DoGetOrientation(const maliput::api::LanePosition& lane_pos) const {
+  MALIPUT_THROW_UNLESS(lane_pos.s() >= lane_geometry_->p0());
+  MALIPUT_THROW_UNLESS(lane_pos.s() <= lane_geometry_->p1());
+  const auto rpy = lane_geometry_->Orientation(lane_pos.srh());
+  return maliput::api::Rotation::FromRpy(rpy.roll_angle(), rpy.pitch_angle(), rpy.yaw_angle());
+}
+
+maliput::api::LanePosition Lane::DoEvalMotionDerivatives(const maliput::api::LanePosition& position,
+                                                         const maliput::api::IsoLaneVelocity& velocity) const {
+  // TODO: Implement
+  MALIPUT_THROW_MESSAGE("Not implemented");
+}
+
+}  // namespace maliput_sparse

--- a/src/base/lane.h
+++ b/src/base/lane.h
@@ -1,0 +1,79 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <memory>
+
+#include <maliput/api/lane_data.h>
+#include <maliput/common/maliput_copyable.h>
+#include <maliput/geometry_base/lane.h>
+#include <maliput/math/vector.h>
+
+#include "geometry/lane_geometry.h"
+
+namespace maliput_sparse {
+
+class Lane : public maliput::geometry_base::Lane {
+ public:
+  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(Lane);
+  /// Constructs a Lane
+  /// @param id The Lane's unique identifier.
+  /// @param elevation_bounds The Lane's elevation bounds.
+  /// @param lane_geometry A LaneGeometry.
+  Lane(const maliput::api::LaneId& id, const maliput::api::HBounds& elevation_bounds,
+       std::unique_ptr<geometry::LaneGeometry> lane_geometry);
+
+  maliput::math::Vector3 ToBackendPosition(const maliput::api::LanePosition& lane_pos) const {
+    return DoToBackendPosition(lane_pos);
+  }
+
+  const geometry::LaneGeometry* lane_geometry() const { return lane_geometry_.get(); }
+
+ private:
+  // maliput::api::Lane private virtual method implementations.
+  //@{
+  double do_length() const override;
+  maliput::api::RBounds do_lane_bounds(double s) const override;
+  maliput::api::RBounds do_segment_bounds(double s) const override;
+  maliput::api::HBounds do_elevation_bounds(double, double) const override;
+
+  maliput::math::Vector3 DoToBackendPosition(const maliput::api::LanePosition& lane_pos) const override;
+  void DoToLanePositionBackend(const maliput::math::Vector3& backend_pos, maliput::api::LanePosition* lane_position,
+                               maliput::math::Vector3* nearest_backend_pos, double* distance) const override;
+  maliput::api::Rotation DoGetOrientation(const maliput::api::LanePosition& lane_pos) const override;
+  maliput::api::LanePosition DoEvalMotionDerivatives(const maliput::api::LanePosition& position,
+                                                     const maliput::api::IsoLaneVelocity& velocity) const override;
+  //@}
+
+  const maliput::api::HBounds elevation_bounds_;
+  std::unique_ptr<geometry::LaneGeometry> lane_geometry_;
+};
+
+}  // namespace maliput_sparse

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(ament_cmake_gtest REQUIRED)
 find_package(ament_cmake_gmock REQUIRED)
 
+add_subdirectory(base)
 add_subdirectory(geometry)

--- a/test/base/CMakeLists.txt
+++ b/test/base/CMakeLists.txt
@@ -1,0 +1,25 @@
+ament_add_gtest(lane_test lane_test.cc)
+
+macro(add_dependencies_to_test target)
+if (TARGET ${target})
+
+      target_include_directories(${target}
+        PRIVATE
+          ${CMAKE_CURRENT_SOURCE_DIR}
+          ${PROJECT_SOURCE_DIR}/include
+          ${PROJECT_SOURCE_DIR}/src
+          ${PROJECT_SOURCE_DIR}/test
+      )
+
+      target_link_libraries(${target}
+          maliput::common
+          maliput::math
+          maliput::test_utilities
+          maliput_sparse::base
+          maliput_sparse::geometry
+      )
+
+    endif()
+endmacro()
+
+add_dependencies_to_test(lane_test)

--- a/test/base/lane_test.cc
+++ b/test/base/lane_test.cc
@@ -1,0 +1,132 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet. All rights reserved.
+// Copyright (c) 2022, Toyota Research Institute. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "base/lane.h"
+
+#include <gtest/gtest.h>
+#include <maliput/api/lane.h>
+#include <maliput/api/lane_data.h>
+#include <maliput/common/assertion_error.h>
+#include <maliput/math/vector.h>
+#include <maliput/test_utilities/maliput_math_compare.h>
+
+#include "maliput_sparse/geometry/line_string.h"
+
+namespace maliput_sparse {
+namespace test {
+namespace {
+
+using geometry::LineString3d;
+using maliput::api::InertialPosition;
+using maliput::api::LanePosition;
+using maliput::api::Rotation;
+using maliput::math::Vector2;
+using maliput::math::Vector3;
+
+struct LaneTestCase {
+  LineString3d left{};
+  LineString3d right{};
+  std::vector<LanePosition> srh{};
+  std::vector<InertialPosition> expected_backend_pos{};
+  std::vector<Rotation> expected_rotation{};
+  double expected_length{};
+};
+
+std::vector<LaneTestCase> LaneTestCases() {
+  return {{
+              LineString3d{{0., 2., 0.}, {100., 2., 0.}} /* left*/,
+              LineString3d{{0., -2., 0.}, {100., -2., 0.}} /* right*/,
+              {{0., 0., 0.}} /* srh */,
+              {{0., 0., 0.}} /* expected_backend_pos */,
+              {Rotation::FromRpy(0., 0., 0.)} /* expected_rotation */,
+              100. /* expected_length */
+          },
+          {
+              // Arc-like lane:
+              //    | |  --> no elevation
+              //  __/ /  --> no elevation
+              //  __ /   --> linear elevation
+              LineString3d{{0., 2., 0.}, {100., 2., 100.}, {200., 102., 100.}, {200., 200., 100.}} /* left*/,
+              LineString3d{{0., -2., 0.}, {100., -2., 100.}, {204., 102., 100.}, {204., 200., 100.}} /* right*/,
+              // Centerline : {0., 0., 0.}, {100., 0., 100.}, {202., 102, 100.}, {202., 200., 100.}
+              {
+                  {50. * std::sqrt(2.), 0., 0.},
+                  {50. * std::sqrt(2.), -2., -2.},
+                  {100. * std::sqrt(2.) + 102. * std::sqrt(2.), 0., 0.},
+                  {100. * std::sqrt(2.) + 102. * std::sqrt(2.) + 98., -1., 4.},
+              } /* srh */,
+              {
+                  {50., 0., 50.},
+                  {50. + 2 * std::sqrt(2.) / 2., -2., 50. - 2 * std::sqrt(2.) / 2.},
+                  {202., 102., 100.},
+                  {203., 200., 104.},
+              } /* expected_backend_pos */,
+              {
+                  Rotation::FromRpy(0., -M_PI / 4., 0.),
+                  Rotation::FromRpy(0., -M_PI / 4., 0.),
+                  Rotation::FromRpy(0., 0., M_PI / 4.),
+                  Rotation::FromRpy(0., 0., M_PI / 2.),
+              } /* expected_rotation */,
+              100. * std::sqrt(2.) + 102. * std::sqrt(2.) + 98. /* expected_length */
+          }};
+}
+
+class LaneTest : public ::testing::TestWithParam<LaneTestCase> {
+ public:
+  static constexpr double kTolerance{1.e-5};
+  static constexpr double kScaleLength{1.};
+
+  const maliput::api::LaneId kLaneId{"dut id"};
+  const maliput::api::HBounds kHBounds{0., 5.};
+  LaneTestCase case_ = GetParam();
+  std::unique_ptr<geometry::LaneGeometry> lane_geometry_ =
+      std::make_unique<geometry::LaneGeometry>(case_.left, case_.right, kTolerance, kScaleLength);
+};
+
+TEST_P(LaneTest, Test) {
+  ASSERT_EQ(case_.srh.size(), case_.expected_backend_pos.size()) << ">>>>> Test case is ill-formed.";
+  ASSERT_EQ(case_.srh.size(), case_.expected_rotation.size()) << ">>>>> Test case is ill-formed.";
+  const Lane dut{kLaneId, kHBounds, std::move(lane_geometry_)};
+  EXPECT_DOUBLE_EQ(case_.expected_length, dut.length());
+  for (std::size_t i = 0; i < case_.srh.size(); ++i) {
+    const auto backend_pos = dut.ToBackendPosition(case_.srh[i]);
+    const auto rpy = dut.GetOrientation(case_.srh[i]);
+    EXPECT_TRUE(maliput::math::test::CompareVectors(case_.expected_backend_pos[i].xyz(), backend_pos, kTolerance))
+        << "Expected backend_pos: " << case_.expected_backend_pos[i].xyz() << " vs backend_pos: " << backend_pos;
+    EXPECT_TRUE(
+        maliput::math::test::CompareVectors(case_.expected_rotation[i].rpy().vector(), rpy.rpy().vector(), kTolerance))
+        << "Expected RPY: " << case_.expected_rotation[i].rpy().vector() << " vs RPY: " << rpy.rpy().vector();
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(LaneTestGroup, LaneTest, ::testing::ValuesIn(LaneTestCases()));
+
+}  // namespace
+}  // namespace test
+}  // namespace maliput_sparse


### PR DESCRIPTION
# 🎉 New feature

Related to #15 

## Summary

Adds Lane class that inherits from `maliput::geometry_base::Lane` class.

## Pendings
- [ ] Implement all the methods. 


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
