### PR TITLE
Implements Lane::DoToLanePositionBackend.

### DIFF
--- a/src/base/lane.cc
+++ b/src/base/lane.cc
@@ -56,8 +56,38 @@ maliput::math::Vector3 Lane::DoToBackendPosition(const maliput::api::LanePositio
   return lane_geometry_->W(lane_pos.srh());
 }
 
+maliput::api::LanePositionResult Lane::ToLanePositionBackend(const maliput::api::InertialPosition& backend_pos) const {
+  maliput::api::LanePosition lane_position;
+  maliput::math::Vector3 nearest_backend_pos;
+  double distance{};
+  DoToLanePositionBackend(backend_pos.xyz(), &lane_position, &nearest_backend_pos, &distance);
+  return {lane_position, maliput::api::InertialPosition::FromXyz(nearest_backend_pos), distance};
+}
+
 void Lane::DoToLanePositionBackend(const maliput::math::Vector3& backend_pos, maliput::api::LanePosition* lane_position,
                                    maliput::math::Vector3* nearest_backend_pos, double* distance) const {
+  MALIPUT_THROW_UNLESS(lane_position != nullptr);
+  MALIPUT_THROW_UNLESS(nearest_backend_pos != nullptr);
+  MALIPUT_THROW_UNLESS(distance != nullptr);
+  // Obtains srh coordinates without saturation in r and h.
+  const maliput::math::Vector3 unsaturated_srh = lane_geometry_->WInverse(backend_pos);
+
+  // Saturates r coordinates to the lane bounds.
+  const maliput::api::RBounds r_bounds = lane_geometry_->RBounds(unsaturated_srh.x());
+  const double saturated_r = std::clamp(unsaturated_srh.y(), r_bounds.min(), r_bounds.max());
+
+  // Saturates h coordinates to the elevation bounds.
+  const maliput::api::HBounds h_bounds = do_elevation_bounds(unsaturated_srh.x(), saturated_r);
+  const double saturated_h = std::clamp(unsaturated_srh.z(), h_bounds.min(), h_bounds.max());
+
+  *lane_position = maliput::api::LanePosition(unsaturated_srh.x(), saturated_r, saturated_h);
+  *nearest_backend_pos = DoToBackendPosition(*lane_position);
+  *distance = (backend_pos - *nearest_backend_pos).norm();
+}
+
+void Lane::DoToSegmentPositionBackend(const maliput::math::Vector3& backend_pos,
+                                      maliput::api::LanePosition* lane_position,
+                                      maliput::math::Vector3* nearest_backend_pos, double* distance) const {
   // TODO: Implement
   MALIPUT_THROW_MESSAGE("Not implemented");
 }

--- a/src/base/lane.h
+++ b/src/base/lane.h
@@ -54,6 +54,8 @@ class Lane : public maliput::geometry_base::Lane {
     return DoToBackendPosition(lane_pos);
   }
 
+  maliput::api::LanePositionResult ToLanePositionBackend(const maliput::api::InertialPosition& backend_pos) const;
+
   const geometry::LaneGeometry* lane_geometry() const { return lane_geometry_.get(); }
 
  private:
@@ -67,6 +69,8 @@ class Lane : public maliput::geometry_base::Lane {
   maliput::math::Vector3 DoToBackendPosition(const maliput::api::LanePosition& lane_pos) const override;
   void DoToLanePositionBackend(const maliput::math::Vector3& backend_pos, maliput::api::LanePosition* lane_position,
                                maliput::math::Vector3* nearest_backend_pos, double* distance) const override;
+  void DoToSegmentPositionBackend(const maliput::math::Vector3& backend_pos, maliput::api::LanePosition* lane_position,
+                                  maliput::math::Vector3* nearest_backend_pos, double* distance) const override;
   maliput::api::Rotation DoGetOrientation(const maliput::api::LanePosition& lane_pos) const override;
   maliput::api::LanePosition DoEvalMotionDerivatives(const maliput::api::LanePosition& position,
                                                      const maliput::api::IsoLaneVelocity& velocity) const override;

--- a/test/base/lane_test.cc
+++ b/test/base/lane_test.cc
@@ -39,13 +39,6 @@
 
 #include "maliput_sparse/geometry/line_string.h"
 
-#define IsLanePositionResultClose(lpr_a, lpr_b, tolerance)                                           \
-  do {                                                                                               \
-    EXPECT_TRUE(IsLanePositionClose(lpr_a.lane_position, lpr_b.lane_position, tolerance));           \
-    EXPECT_TRUE(IsInertialPositionClose(lpr_a.nearest_position, lpr_b.nearest_position, tolerance)); \
-    EXPECT_NEAR(lpr_a.distance, lpr_b.distance, tolerance);                                          \
-  } while (0);
-
 namespace maliput_sparse {
 namespace test {
 namespace {
@@ -195,7 +188,7 @@ std::vector<ToLaneSegmentPositionTestCase> ToLaneSegmentPositionTestCases() {
               {50., 0., 50.} /* nearest_position */,
               0. /* distance */
           },
-          // A the edge of the lane.
+          // At the edge of the lane.
           {
               {50. * std::sqrt(2.), 2., 0.} /* lane_position */,
               {50., 2., 50.} /* nearest_position */,

--- a/test/base/lane_test.cc
+++ b/test/base/lane_test.cc
@@ -50,6 +50,7 @@ using maliput::api::LanePositionResult;
 using maliput::api::Rotation;
 using maliput::api::test::IsInertialPositionClose;
 using maliput::api::test::IsLanePositionClose;
+using maliput::api::test::IsLanePositionResultClose;
 using maliput::api::test::IsRotationClose;
 using maliput::math::Vector2;
 using maliput::math::Vector3;
@@ -150,9 +151,10 @@ TEST_P(LaneTest, Test) {
     const auto backend_pos = dut->ToBackendPosition(case_.srh[i]);
     const auto rpy = dut->GetOrientation(case_.srh[i]);
     const auto lane_position_result = dut->ToLanePositionBackend(case_.expected_backend_pos[i]);
-    IsRotationClose(case_.expected_rotation[i], rpy, kTolerance);
-    IsInertialPositionClose(case_.expected_backend_pos[i], InertialPosition::FromXyz(backend_pos), kTolerance);
-    IsLanePositionResultClose(case_.expected_lane_position_result[i], lane_position_result, kTolerance);
+    EXPECT_TRUE(IsRotationClose(case_.expected_rotation[i], rpy, kTolerance));
+    EXPECT_TRUE(
+        IsInertialPositionClose(case_.expected_backend_pos[i], InertialPosition::FromXyz(backend_pos), kTolerance));
+    EXPECT_TRUE(IsLanePositionResultClose(case_.expected_lane_position_result[i], lane_position_result, kTolerance));
   }
 }
 
@@ -226,7 +228,7 @@ TEST_P(ToLaneSegmentPositionTest, Test) {
   EXPECT_DOUBLE_EQ(case_.expected_length, dut->length());
   for (std::size_t i = 0; i < case_.backend_pos.size(); ++i) {
     const auto lane_position_result = dut->ToLanePositionBackend(case_.backend_pos[i]);
-    IsLanePositionResultClose(case_.expected_lane_position_result[i], lane_position_result, kTolerance);
+    EXPECT_TRUE(IsLanePositionResultClose(case_.expected_lane_position_result[i], lane_position_result, kTolerance));
   }
 }
 


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/maliput/maliput_sparse/issues/15

## Summary

Implements Lane::DoToLanePosition backend method.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
