### PR TITLE
Lane::DoEvalMotionDerivatives.

### DIFF
--- a/src/base/lane.cc
+++ b/src/base/lane.cc
@@ -101,8 +101,10 @@ maliput::api::Rotation Lane::DoGetOrientation(const maliput::api::LanePosition& 
 
 maliput::api::LanePosition Lane::DoEvalMotionDerivatives(const maliput::api::LanePosition& position,
                                                          const maliput::api::IsoLaneVelocity& velocity) const {
-  // TODO: Implement
-  MALIPUT_THROW_MESSAGE("Not implemented");
+  // The definition of path-length of a path along σ yields dσ = |∂W/∂s| ds
+  // evaluated at (s, r, h).
+  const double ds_dsigma = lane_geometry_->WDot(position.s()).norm() / lane_geometry_->WDot(position.srh()).norm();
+  return {ds_dsigma * velocity.sigma_v, velocity.rho_v, velocity.eta_v};
 }
 
 }  // namespace maliput_sparse


### PR DESCRIPTION
# 🎉 New feature

Closes #26 

## Summary
Implements `Lane::DoEvalMotionDerivatives`


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
