### PR TITLE
Overrides pendings RoadGeometry methods.

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 set(BASE_SOURCES
   lane.cc
+  road_geometry.cc
 )
 
 add_library(base ${BASE_SOURCES})

--- a/src/base/road_geometry.cc
+++ b/src/base/road_geometry.cc
@@ -1,0 +1,140 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "base/road_geometry.h"
+
+#include <algorithm>
+#include <limits>
+
+#include <maliput/geometry_base/brute_force_find_road_positions_strategy.h>
+#include <maliput/geometry_base/filter_positions.h>
+
+namespace maliput_sparse {
+namespace {
+
+// Evaluates if `new_road_position_result` provides a closer api::RoadPositionResult than `road_position_result`.
+//
+// _Closer_ means:
+// - When `new_road_position_result.distance` is smaller than
+//   `road_position_result.distance` by more than malidrive::constants::kStrictLinearTolerance.
+// - When distances are equal, if both positions fall within their
+//   respective lane's lane bounds or none do, the new r-coordinate
+//   is smaller than `road_position_result.road_position.pos.r()`.
+// - When the new position falls within `lane`'s lane bounds and
+//   `road_position_result.road_position.pos` doesn't.
+//
+bool IsNewRoadPositionResultCloser(const maliput::api::RoadPositionResult& new_road_position_result,
+                                   const maliput::api::RoadPositionResult& road_position_result) {
+  const double delta = new_road_position_result.distance - road_position_result.distance;
+  const bool different_segment = road_position_result.road_position.lane->segment()->id() !=
+                                 new_road_position_result.road_position.lane->segment()->id();
+
+  // When lanes belong to the same segment is expected that the distance value is almost equal so we can't use the
+  // distance as main condition. When lanes don't belong to the same segment we can use the distance as main
+  // condition.
+  if (different_segment) {
+    if (delta < -std::numeric_limits<double>::epsilon()) {
+      return true;
+    }
+    if (delta >= std::numeric_limits<double>::epsilon()) {
+      return false;
+    }
+  }
+
+  auto is_within_lane_bounds = [](double r, const maliput::api::RBounds& lane_bounds) {
+    return r >= lane_bounds.min() && r < lane_bounds.max();
+  };
+  // They are almost equal so it is worth checking the `r` coordinate and the
+  // lane bounds.
+  // When both r-coordinates fall within lane bounds or outside, the position
+  // with the minimum absolute r-coordinate prevails.
+  // When the new r-coordinate is within lane bounds, and the previous position
+  // does not fall within lane bounds, the new result prevails.
+  const maliput::api::RBounds new_lane_bounds =
+      new_road_position_result.road_position.lane->lane_bounds(new_road_position_result.road_position.pos.s());
+  const maliput::api::RBounds current_lane_bounds =
+      road_position_result.road_position.lane->lane_bounds(road_position_result.road_position.pos.s());
+  const bool is_new_within_lane_bounds =
+      is_within_lane_bounds(new_road_position_result.road_position.pos.r(), new_lane_bounds);
+  const bool is_current_within_lane_bounds =
+      is_within_lane_bounds(road_position_result.road_position.pos.r(), current_lane_bounds);
+  if ((is_new_within_lane_bounds && is_current_within_lane_bounds) ||
+      (!is_new_within_lane_bounds && !is_current_within_lane_bounds)) {
+    if (std::abs(new_road_position_result.road_position.pos.r()) <
+        std::abs(road_position_result.road_position.pos.r())) {
+      return true;
+    }
+  } else if (is_new_within_lane_bounds && !is_current_within_lane_bounds) {
+    return true;
+  }
+  return false;
+}
+
+}  // namespace
+
+maliput::api::RoadPositionResult RoadGeometry::DoToRoadPosition(
+    const maliput::api::InertialPosition& inertial_position,
+    const std::optional<maliput::api::RoadPosition>& hint) const {
+  maliput::api::RoadPositionResult result;
+  if (hint.has_value()) {
+    MALIPUT_THROW_UNLESS(hint->lane != nullptr);
+    const maliput::api::LanePositionResult lane_pos = hint->lane->ToLanePosition(inertial_position);
+    result = maliput::api::RoadPositionResult{
+        {hint->lane, lane_pos.lane_position}, lane_pos.nearest_position, lane_pos.distance};
+  } else {
+    const std::vector<maliput::api::RoadPositionResult> road_position_results =
+        DoFindRoadPositions(inertial_position, std::numeric_limits<double>::infinity());
+    MALIPUT_THROW_UNLESS(road_position_results.size());
+
+    // Filter the candidates within a linear tolerance of distance.
+    const std::vector<maliput::api::RoadPositionResult> near_road_positions_results =
+        maliput::geometry_base::FilterRoadPositionResults(
+            road_position_results, [tol = linear_tolerance()](const maliput::api::RoadPositionResult& result) {
+              return result.distance <= tol;
+            });
+
+    // If it is empty then I should use all the road position results.
+    const std::vector<maliput::api::RoadPositionResult>& filtered_road_position_results =
+        near_road_positions_results.empty() ? road_position_results : near_road_positions_results;
+    result = filtered_road_position_results[0];
+    for (const auto& road_position_result : filtered_road_position_results) {
+      if (IsNewRoadPositionResultCloser(road_position_result, result)) {
+        result = road_position_result;
+      }
+    }
+  }
+  return result;
+}
+
+std::vector<maliput::api::RoadPositionResult> RoadGeometry::DoFindRoadPositions(
+    const maliput::api::InertialPosition& inertial_position, double radius) const {
+  return maliput::geometry_base::BruteForceFindRoadPositionsStrategy(this, inertial_position, radius);
+}
+
+}  // namespace maliput_sparse

--- a/src/base/road_geometry.h
+++ b/src/base/road_geometry.h
@@ -47,16 +47,16 @@ class RoadGeometry final : public maliput::geometry_base::RoadGeometry {
                                              inertial_to_backend_frame_translation) {}
 
  private:
+  // TODO(https://github.com/maliput/maliput/pull/517): Remove these overrides once default implementations are
+  // provided.
+  // @{
   maliput::api::RoadPositionResult DoToRoadPosition(
       const maliput::api::InertialPosition& inertial_position,
-      const std::optional<maliput::api::RoadPosition>& hint = std::nullopt) const override {
-    return maliput::api::RoadPositionResult();
-  }
+      const std::optional<maliput::api::RoadPosition>& hint = std::nullopt) const override;
 
   std::vector<maliput::api::RoadPositionResult> DoFindRoadPositions(
-      const maliput::api::InertialPosition& inertial_position, double radius) const {
-    return std::vector<maliput::api::RoadPositionResult>();
-  }
+      const maliput::api::InertialPosition& inertial_position, double radius) const override;
+  // @}
 };
 
 }  // namespace maliput_sparse

--- a/test/base/CMakeLists.txt
+++ b/test/base/CMakeLists.txt
@@ -19,6 +19,7 @@ if (TARGET ${target})
           maliput::math
           maliput::test_utilities
           maliput_sparse::base
+          maliput_sparse::builder
           maliput_sparse::geometry
       )
 

--- a/test/base/road_geometry_test.cc
+++ b/test/base/road_geometry_test.cc
@@ -53,6 +53,8 @@ GTEST_TEST(RoadGeometryTest, Stub) {
   });
 }
 
+// TODO(francocipollone): Add tests for the ToRoadPosition and FindRoadPosition methods.
+
 }  // namespace
 }  // namespace test
 }  // namespace maliput_sparse

--- a/test/base/road_geometry_test.cc
+++ b/test/base/road_geometry_test.cc
@@ -36,12 +36,22 @@
 #include <maliput/api/lane_data.h>
 #include <maliput/api/road_geometry.h>
 #include <maliput/math/vector.h>
+#include <maliput/test_utilities/maliput_types_compare.h>
+
+#include "maliput_sparse/builder/builder.h"
+#include "maliput_sparse/geometry/line_string.h"
 
 namespace maliput_sparse {
 namespace test {
 namespace {
 
-GTEST_TEST(RoadGeometryTest, Stub) {
+using maliput::api::InertialPosition;
+using maliput::api::LanePosition;
+using maliput::math::Vector3;
+using maliput_sparse::builder::RoadGeometryBuilder;
+using maliput_sparse::geometry::LineString3d;
+
+GTEST_TEST(RoadGeometryStubTest, Stub) {
   constexpr double kLinearTolerance{1e-12};
   constexpr double kAngularTolerance{1e-12};
   constexpr double kScaleLength{1.};
@@ -53,7 +63,88 @@ GTEST_TEST(RoadGeometryTest, Stub) {
   });
 }
 
-// TODO(francocipollone): Add tests for the ToRoadPosition and FindRoadPosition methods.
+class RoadGeometryTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    dut_ = builder_.StartJunction()
+               .Id(kJunctionAId)
+               .StartSegment()
+               .Id(kSegmentAId)
+               .StartLane()
+               .Id(kLaneAId)
+               .StartLaneGeometry()
+               .LeftLineString(kLeftLineStringA)
+               .RightLineString(kRightLineStringA)
+               .EndLaneGeometry()
+               .EndLane()
+               .StartLane()
+               .Id(kLaneBId)
+               .StartLaneGeometry()
+               .LeftLineString(kLeftLineStringB)
+               .RightLineString(kRightLineStringB)
+               .EndLaneGeometry()
+               .EndLane()
+               .EndSegment()
+               .EndJunction()
+               .StartBranchPoints()
+               .EndBranchPoints()
+               .Build();
+  }
+
+  static constexpr double kLinearTolerance{1e-12};
+  const maliput::api::RoadGeometryId kRoadGeometryId{"custom_rg_id"};
+  const maliput::math::Vector3 kInertialToBackendFrameTranslation{0., 0., 0.};
+  const maliput::api::JunctionId kJunctionAId{"junction_a"};
+  const maliput::api::SegmentId kSegmentAId{"segment_a"};
+  const maliput::api::LaneId kLaneAId{"lane_a"};
+  const maliput::api::LaneId kLaneBId{"lane_b"};
+  const LineString3d kLeftLineStringA{Vector3{0., 10., 0.}, Vector3{10., 10., 0.}};
+  const LineString3d kRightLineStringA{Vector3{0., 5., 0.}, Vector3{10., 5., 0.}};
+  const LineString3d kLeftLineStringB{Vector3{0., 5., 0.}, Vector3{10., 5., 0.}};
+  const LineString3d kRightLineStringB{Vector3{0., 0., 0.}, Vector3{10., 0., 0.}};
+
+  RoadGeometryBuilder builder_;
+  std::unique_ptr<maliput::api::RoadGeometry> dut_;
+};
+
+TEST_F(RoadGeometryTest, OnLaneA) {
+  const maliput::api::InertialPosition inertial_pos{5., 8., 0.};
+  auto lane = dut_->ById().GetLane(kLaneAId);
+
+  const maliput::api::RoadPositionResult expected_road_position_result{
+      {lane, LanePosition{5., 0.5, 0.}},
+      {5., 8., 0.}, /* nearest position */
+      0.,           /* distance */
+  };
+  EXPECT_TRUE(maliput::api::test::IsRoadPositionResultClose(expected_road_position_result,
+                                                            dut_->ToRoadPosition(inertial_pos), kLinearTolerance));
+}
+
+TEST_F(RoadGeometryTest, OnLaneB) {
+  const maliput::api::InertialPosition inertial_pos{5., 0., 0.};
+  auto lane = dut_->ById().GetLane(kLaneBId);
+
+  const maliput::api::RoadPositionResult expected_road_position_result{
+      {lane, LanePosition{5., -2.5, 0.}},
+      {5., 0., 0.}, /* nearest position */
+      0.,           /* distance */
+  };
+  EXPECT_TRUE(maliput::api::test::IsRoadPositionResultClose(expected_road_position_result,
+                                                            dut_->ToRoadPosition(inertial_pos), kLinearTolerance));
+}
+
+TEST_F(RoadGeometryTest, CloseToLaneA) {
+  const maliput::api::InertialPosition inertial_pos{5., 11., 0.};
+  auto lane = dut_->ById().GetLane(kLaneAId);
+
+  const maliput::api::RoadPositionResult expected_road_position_result{
+      {lane, LanePosition{5., 2.5, 0.}},
+      {5., 10., 0.}, /* nearest position */
+      1.,            /* distance */
+  };
+  EXPECT_TRUE(maliput::api::test::IsRoadPositionResultClose(expected_road_position_result,
+                                                            dut_->ToRoadPosition(inertial_pos), kLinearTolerance));
+}
 
 }  // namespace
 }  // namespace test


### PR DESCRIPTION
# 🎉 New feature

related to #17 

## Summary

ToRoadPosition and FIndRoadPosition methods are implemented overriding the pure virtual methods from maliput::api::RoadGeometry

## Pendings
- [x] Add tests

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
