### PR TITLE
Supports passing custom centerline to the lane.

### DIFF
--- a/include/maliput_sparse/builder/builder.h
+++ b/include/maliput_sparse/builder/builder.h
@@ -162,6 +162,11 @@ class LaneGeometryBuilder final : public details::NestedBuilder<LaneBuilder> {
   /// @return A reference to this LaneGeometryBuilder.
   LaneGeometryBuilder& RightLineString(const maliput_sparse::geometry::LineString3d& right_line_string);
 
+  /// @brief Set the center maliput_sparse::geometry::LineString of the LaneGeometry.
+  /// @param center_line_string The center maliput_sparse::geometry::LineString to set in the LaneGeometry.
+  /// @return A reference to this LaneGeometryBuilder.
+  LaneGeometryBuilder& CenterLineString(const maliput_sparse::geometry::LineString3d& center_line_string);
+
   /// @brief Finalizes the construction of the LaneGeometry and sets it to the parent LaneBuilder.
   /// @pre Left and right LineStrings must be set before calling this method.
   /// @throws maliput::common::assertion_error When the left and right LineStrings were not set.
@@ -169,6 +174,7 @@ class LaneGeometryBuilder final : public details::NestedBuilder<LaneBuilder> {
   LaneBuilder& EndLaneGeometry();
 
  private:
+  std::optional<maliput_sparse::geometry::LineString3d> center_line_string_{};
   std::optional<maliput_sparse::geometry::LineString3d> left_line_string_{};
   std::optional<maliput_sparse::geometry::LineString3d> right_line_string_{};
 };

--- a/include/maliput_sparse/geometry/lane_geometry.h
+++ b/include/maliput_sparse/geometry/lane_geometry.h
@@ -64,6 +64,22 @@ class LaneGeometry {
   /// @throws maliput::common::assertion_error When @p linear_tolerance or
   ///         @p scale_length are negative.
   LaneGeometry(const LineString3d& left, const LineString3d& right, double linear_tolerance, double scale_length);
+
+  /// Constructs a LaneGeometry
+  /// @param center Center line of the lane.
+  /// @param left Left boundary of the lane.
+  /// @param right Right boundary of the lane.
+  /// @param linear_tolerance It is expected to be the same as
+  ///        maliput::api::RoadGeometry::linear_tolerance(). It must be non
+  ///        negative.
+  /// @param scale_length It is expected to be the same as
+  ///        maliput::api::RoadGeometry::scale_length(). It must be non
+  ///        negative.
+  /// @throws maliput::common::assertion_error When @p linear_tolerance or
+  ///         @p scale_length are negative.
+  LaneGeometry(const LineString3d& center, const LineString3d& left, const LineString3d& right, double linear_tolerance,
+               double scale_length);
+
   ~LaneGeometry() = default;
 
   double p0() const { return 0.; }

--- a/src/builder/builder.cc
+++ b/src/builder/builder.cc
@@ -51,12 +51,25 @@ LaneGeometryBuilder& LaneGeometryBuilder::RightLineString(
   return *this;
 }
 
+LaneGeometryBuilder& LaneGeometryBuilder::CenterLineString(
+    const maliput_sparse::geometry::LineString3d& center_line_string) {
+  center_line_string_.emplace(center_line_string);
+  return *this;
+}
+
 LaneBuilder& LaneGeometryBuilder::EndLaneGeometry() {
   MALIPUT_THROW_UNLESS(left_line_string_.has_value() && right_line_string_.has_value());
   const double linear_tolerance = Parent()->Parent()->Parent()->Parent()->linear_tolerance({});
   const double scale_length = Parent()->Parent()->Parent()->Parent()->scale_length({});
-  auto lane_geometry = std::make_unique<maliput_sparse::geometry::LaneGeometry>(
-      left_line_string_.value(), right_line_string_.value(), linear_tolerance, scale_length);
+  std::unique_ptr<maliput_sparse::geometry::LaneGeometry> lane_geometry;
+  if (center_line_string_.has_value()) {
+    lane_geometry = std::make_unique<maliput_sparse::geometry::LaneGeometry>(
+        center_line_string_.value(), left_line_string_.value(), right_line_string_.value(), linear_tolerance,
+        scale_length);
+  } else {
+    lane_geometry = std::make_unique<maliput_sparse::geometry::LaneGeometry>(
+        left_line_string_.value(), right_line_string_.value(), linear_tolerance, scale_length);
+  }
   Parent()->SetLaneGeometry({}, std::move(lane_geometry));
   return End();
 }

--- a/src/builder/builder.cc
+++ b/src/builder/builder.cc
@@ -61,15 +61,14 @@ LaneBuilder& LaneGeometryBuilder::EndLaneGeometry() {
   MALIPUT_THROW_UNLESS(left_line_string_.has_value() && right_line_string_.has_value());
   const double linear_tolerance = Parent()->Parent()->Parent()->Parent()->linear_tolerance({});
   const double scale_length = Parent()->Parent()->Parent()->Parent()->scale_length({});
-  std::unique_ptr<maliput_sparse::geometry::LaneGeometry> lane_geometry;
-  if (center_line_string_.has_value()) {
-    lane_geometry = std::make_unique<maliput_sparse::geometry::LaneGeometry>(
-        center_line_string_.value(), left_line_string_.value(), right_line_string_.value(), linear_tolerance,
-        scale_length);
-  } else {
-    lane_geometry = std::make_unique<maliput_sparse::geometry::LaneGeometry>(
-        left_line_string_.value(), right_line_string_.value(), linear_tolerance, scale_length);
-  }
+  std::unique_ptr<maliput_sparse::geometry::LaneGeometry> lane_geometry =
+      center_line_string_.has_value()
+          ? std::make_unique<maliput_sparse::geometry::LaneGeometry>(
+                center_line_string_.value(), left_line_string_.value(), right_line_string_.value(), linear_tolerance,
+                scale_length)
+          : std::make_unique<maliput_sparse::geometry::LaneGeometry>(
+                left_line_string_.value(), right_line_string_.value(), linear_tolerance, scale_length);
+
   Parent()->SetLaneGeometry({}, std::move(lane_geometry));
   return End();
 }

--- a/src/geometry/lane_geometry.cc
+++ b/src/geometry/lane_geometry.cc
@@ -40,11 +40,15 @@ namespace {}  // namespace
 
 LaneGeometry::LaneGeometry(const LineString3d& left, const LineString3d& right, double linear_tolerance,
                            double scale_length)
+    : LaneGeometry(utility::ComputeCenterline3d(left, right), left, right, linear_tolerance, scale_length) {}
+
+LaneGeometry::LaneGeometry(const LineString3d& center, const LineString3d& left, const LineString3d& right,
+                           double linear_tolerance, double scale_length)
     : left_(left),
       right_(right),
       linear_tolerance_(linear_tolerance),
       scale_length_(scale_length),
-      centerline_(utility::ComputeCenterline3d(left_, right_)) {}
+      centerline_(center) {}
 
 double LaneGeometry::ArcLength() const { return centerline_.length(); }
 

--- a/test/builder/builder_test.cc
+++ b/test/builder/builder_test.cc
@@ -276,9 +276,9 @@ TEST_F(RoadGeometryBuilderTest, LaneGeometryBuilderWithMissingLineStrings) {
       maliput::common::assertion_error);
 }
 
-TEST_F(RoadGeometryBuilderTest, LaneGeometryBuilderWithAndWithoutCenter) {
-  // No throws as LaneGeometryBuilder is properly used.
-  // Centerline isn't passed to the builder.
+// No throws as LaneGeometryBuilder is properly used.
+// Centerline isn't passed to the builder.
+TEST_F(RoadGeometryBuilderTest, LaneGeometryBuilderWithoutCenter) {
   EXPECT_NO_THROW(
       // clang-format off
       RoadGeometryBuilder()
@@ -296,11 +296,14 @@ TEST_F(RoadGeometryBuilderTest, LaneGeometryBuilderWithAndWithoutCenter) {
               .EndSegment()
       // clang-format on
   );
+}
 
-  // No throws as LaneGeometryBuilder is properly used.
-  // Centerline is submitted to the builder.
-  EXPECT_NO_THROW(const auto kCenterline{geometry::utility::ComputeCenterline3d(kLeftLineStringA, kRightLineStringA)};
-                  // clang-format off
+// No throws as LaneGeometryBuilder is properly used.
+// Centerline is submitted to the builder.
+TEST_F(RoadGeometryBuilderTest, LaneGeometryBuilderWithCenter) {
+  const auto kCenterline{geometry::utility::ComputeCenterline3d(kLeftLineStringA, kRightLineStringA)};
+  EXPECT_NO_THROW(
+      // clang-format off
       RoadGeometryBuilder()
           .StartJunction()
               .Id(kJunctionAId)
@@ -315,7 +318,7 @@ TEST_F(RoadGeometryBuilderTest, LaneGeometryBuilderWithAndWithoutCenter) {
                       .EndLaneGeometry()
                   .EndLane()
               .EndSegment()
-                  // clang-format on
+      // clang-format on
   );
 }
 

--- a/test/builder/builder_test.cc
+++ b/test/builder/builder_test.cc
@@ -46,6 +46,7 @@
 
 #include "maliput_sparse/geometry/lane_geometry.h"
 #include "maliput_sparse/geometry/line_string.h"
+#include "maliput_sparse/geometry/utility/geometry.h"
 
 namespace maliput_sparse {
 namespace builder {
@@ -142,13 +143,13 @@ class RoadGeometryBuilderTest : public ::testing::Test {
   const maliput::api::LaneId kLaneCId{"lane_c"};
   const maliput::api::LaneId kLaneDId{"unset_id"};
   const LineString3d kLeftLineStringA{Vector3{0., 0., 0.}, Vector3{10., 0., 0.}};
-  const LineString3d kRigthLineStringA{Vector3{0., 5., 0.}, Vector3{10., 5., 0.}};
+  const LineString3d kRightLineStringA{Vector3{0., 5., 0.}, Vector3{10., 5., 0.}};
   const LineString3d kLeftLineStringB{Vector3{0., 5., 0.}, Vector3{10., 5., 0.}};
-  const LineString3d kRigthLineStringB{Vector3{0., 10., 0.}, Vector3{10., 10., 0.}};
+  const LineString3d kRightLineStringB{Vector3{0., 10., 0.}, Vector3{10., 10., 0.}};
   const LineString3d kLeftLineStringC{Vector3{0., 0., 0.}, Vector3{0., 10., 0.}};
-  const LineString3d kRigthLineStringC{Vector3{5., 0., 0.}, Vector3{5., 10., 0.}};
+  const LineString3d kRightLineStringC{Vector3{5., 0., 0.}, Vector3{5., 10., 0.}};
   const LineString3d kLeftLineStringD{Vector3{20., 0., 0.}, Vector3{30., 5., 0.}};
-  const LineString3d kRigthLineStringD{Vector3{20., 0., 0.}, Vector3{30., 5., 0.}};
+  const LineString3d kRightLineStringD{Vector3{20., 0., 0.}, Vector3{30., 5., 0.}};
   const maliput::api::HBounds kHBoundsA{0., 1.};
   const maliput::api::HBounds kHBoundsB{-1., 2.};
   const maliput::api::HBounds kHBoundsC{-2., 3.};
@@ -266,13 +267,56 @@ TEST_F(RoadGeometryBuilderTest, LaneGeometryBuilderWithMissingLineStrings) {
                   .StartLane()
                       .Id(kLaneAId)
                       .StartLaneGeometry()
-                          .RightLineString(kRigthLineStringA)
+                          .RightLineString(kRightLineStringA)
                       .EndLaneGeometry()
                   .EndLane()
               .EndSegment()
       // clang-format on
       ,
       maliput::common::assertion_error);
+}
+
+TEST_F(RoadGeometryBuilderTest, LaneGeometryBuilderWithAndWithoutCenter) {
+  // No throws as LaneGeometryBuilder is properly used.
+  // Centerline isn't passed to the builder.
+  EXPECT_NO_THROW(
+      // clang-format off
+      RoadGeometryBuilder()
+          .StartJunction()
+              .Id(kJunctionAId)
+              .StartSegment()
+                  .Id(kSegmentAId)
+                  .StartLane()
+                      .Id(kLaneAId)
+                      .StartLaneGeometry()
+                          .LeftLineString(kLeftLineStringA)
+                          .RightLineString(kRightLineStringA)
+                      .EndLaneGeometry()
+                  .EndLane()
+              .EndSegment()
+      // clang-format on
+  );
+
+  // No throws as LaneGeometryBuilder is properly used.
+  // Centerline is submitted to the builder.
+  EXPECT_NO_THROW(const auto kCenterline{geometry::utility::ComputeCenterline3d(kLeftLineStringA, kRightLineStringA)};
+                  // clang-format off
+      RoadGeometryBuilder()
+          .StartJunction()
+              .Id(kJunctionAId)
+              .StartSegment()
+                  .Id(kSegmentAId)
+                  .StartLane()
+                      .Id(kLaneAId)
+                      .StartLaneGeometry()
+                          .CenterLineString(kCenterline)
+                          .LeftLineString(kLeftLineStringA)
+                          .RightLineString(kRightLineStringA)
+                      .EndLaneGeometry()
+                  .EndLane()
+              .EndSegment()
+                  // clang-format on
+  );
 }
 
 // Evaluates a case where all calls are executed at once and none of them fail their invariants.
@@ -293,7 +337,7 @@ TEST_F(RoadGeometryBuilderTest, CompleteCase) {
                       .HeightBounds(kHBoundsA)
                       .StartLaneGeometry()
                           .LeftLineString(kLeftLineStringA)  
-                          .RightLineString(kRigthLineStringA)
+                          .RightLineString(kRightLineStringA)
                       .EndLaneGeometry()
                   .EndLane()
                   .StartLane()
@@ -301,7 +345,7 @@ TEST_F(RoadGeometryBuilderTest, CompleteCase) {
                       .HeightBounds(kHBoundsB)
                       .StartLaneGeometry()
                           .LeftLineString(kLeftLineStringB)  
-                          .RightLineString(kRigthLineStringB)
+                          .RightLineString(kRightLineStringB)
                       .EndLaneGeometry()
                   .EndLane()
               .EndSegment()
@@ -312,7 +356,7 @@ TEST_F(RoadGeometryBuilderTest, CompleteCase) {
                       .HeightBounds(kHBoundsC)
                       .StartLaneGeometry()
                           .LeftLineString(kLeftLineStringC)  
-                          .RightLineString(kRigthLineStringC)
+                          .RightLineString(kRightLineStringC)
                       .EndLaneGeometry()
                   .EndLane()
               .EndSegment()
@@ -322,7 +366,7 @@ TEST_F(RoadGeometryBuilderTest, CompleteCase) {
                   .StartLane()
                       .StartLaneGeometry()
                           .LeftLineString(kLeftLineStringD)  
-                          .RightLineString(kRigthLineStringD)
+                          .RightLineString(kRightLineStringD)
                       .EndLaneGeometry()
                   .EndLane()
               .EndSegment()
@@ -431,13 +475,13 @@ TEST_F(RoadGeometryBuilderTest, CompleteCase) {
 /// </pre>
 TEST_F(RoadGeometryBuilderTest, OutgoingBranches) {
   const LineString3d kLeftLineStringA{Vector3{0., 0., 0.}, Vector3{100., 0., 0.}};
-  const LineString3d kRigthLineStringA{Vector3{0., 5., 0.}, Vector3{100., 5., 0.}};
+  const LineString3d kRightLineStringA{Vector3{0., 5., 0.}, Vector3{100., 5., 0.}};
   const LineString3d kLeftLineStringB{Vector3{100., 0., 0.}, Vector3{200., 55., 0.}};
-  const LineString3d kRigthLineStringB{Vector3{100., 5., 0.}, Vector3{200., 50., 0.}};
+  const LineString3d kRightLineStringB{Vector3{100., 5., 0.}, Vector3{200., 50., 0.}};
   const LineString3d kLeftLineStringC{Vector3{100., 0., 0.}, Vector3{200., 0., 0.}};
-  const LineString3d kRigthLineStringC{Vector3{100., 5., 0.}, Vector3{200., 5., 0.}};
+  const LineString3d kRightLineStringC{Vector3{100., 5., 0.}, Vector3{200., 5., 0.}};
   const LineString3d kLeftLineStringD{Vector3{100., 0., 0.}, Vector3{200., -55., 0.}};
-  const LineString3d kRigthLineStringD{Vector3{100., 5., 0.}, Vector3{200., -50., 0.}};
+  const LineString3d kRightLineStringD{Vector3{100., 5., 0.}, Vector3{200., -50., 0.}};
   const auto start = maliput::api::LaneEnd::Which::kStart;
   const auto finish = maliput::api::LaneEnd::Which::kFinish;
   const maliput::api::SegmentId kSegmentCId{"segment_c"};
@@ -458,7 +502,7 @@ TEST_F(RoadGeometryBuilderTest, OutgoingBranches) {
                       .Id(kLaneAId)
                       .StartLaneGeometry()
                           .LeftLineString(kLeftLineStringA)  
-                          .RightLineString(kRigthLineStringA)
+                          .RightLineString(kRightLineStringA)
                       .EndLaneGeometry()
                   .EndLane()
               .EndSegment()
@@ -468,7 +512,7 @@ TEST_F(RoadGeometryBuilderTest, OutgoingBranches) {
                       .Id(kLaneBId)
                       .StartLaneGeometry()
                           .LeftLineString(kLeftLineStringB)  
-                          .RightLineString(kRigthLineStringB)
+                          .RightLineString(kRightLineStringB)
                       .EndLaneGeometry()
                   .EndLane()
               .EndSegment()
@@ -478,7 +522,7 @@ TEST_F(RoadGeometryBuilderTest, OutgoingBranches) {
                       .Id(kLaneCId)
                       .StartLaneGeometry()
                           .LeftLineString(kLeftLineStringC)  
-                          .RightLineString(kRigthLineStringC)
+                          .RightLineString(kRightLineStringC)
                       .EndLaneGeometry()
                   .EndLane()
               .EndSegment()
@@ -488,7 +532,7 @@ TEST_F(RoadGeometryBuilderTest, OutgoingBranches) {
                       .Id(kLaneDId)
                       .StartLaneGeometry()
                           .LeftLineString(kLeftLineStringD)  
-                          .RightLineString(kRigthLineStringD)
+                          .RightLineString(kRightLineStringD)
                       .EndLaneGeometry()
                   .EndLane()
               .EndSegment()

--- a/test/geometry/lane_geometry_test.cc
+++ b/test/geometry/lane_geometry_test.cc
@@ -42,6 +42,25 @@ namespace {
 using maliput::math::Vector2;
 using maliput::math::Vector3;
 
+class LaneGeometryBasicTest : public testing::Test {
+ public:
+  const LineString3d centerline{{0., 0., 0.}, {50., 0., 0.}, {100., 0., 0.}};
+  const LineString3d left{{0., 2., 0.}, {100., 2., 0.}};
+  const LineString3d right{{0., -2., 0.}, {100., -2., 0.}};
+  const double kTolerance{1e-12};
+  const double kScaleLength{1.};
+};
+
+TEST_F(LaneGeometryBasicTest, ConstructorWithCenter) {
+  const LaneGeometry lane(centerline, left, right, kTolerance, kScaleLength);
+  EXPECT_EQ(lane.centerline(), centerline);
+}
+
+TEST_F(LaneGeometryBasicTest, ConstructorWithoutCenter) {
+  const LaneGeometry lane(left, right, kTolerance, kScaleLength);
+  EXPECT_EQ(lane.centerline(), centerline);
+}
+
 struct OrientationTestCase {
   LineString3d left{};
   LineString3d right{};


### PR DESCRIPTION
# 🎉 New feature

Related to #32 

## Summary
 - Centerline for the Lane could be passed via builder api.
 - If no centerline is passed then the centerline is computed.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
