### PR TITLE
Uses RangeValidator within LaneGeometry.

### DIFF
--- a/include/maliput_sparse/geometry/lane_geometry.h
+++ b/include/maliput_sparse/geometry/lane_geometry.h
@@ -33,6 +33,7 @@
 
 #include <maliput/api/lane_data.h>
 #include <maliput/common/maliput_copyable.h>
+#include <maliput/common/range_validator.h>
 #include <maliput/math/roll_pitch_yaw.h>
 #include <maliput/math/vector.h>
 
@@ -157,11 +158,13 @@ class LaneGeometry {
   maliput::math::Vector3 ToLateralPos(const LineStringType& line_string_type, double p) const;
 
  private:
+  static constexpr double kEpsilon{1e-12};
   const LineString3d left_;
   const LineString3d right_;
   const double linear_tolerance_{};
   const double scale_length_{};
-  LineString3d centerline_;
+  const LineString3d centerline_;
+  const maliput::common::RangeValidator range_validator_;
 };
 
 }  // namespace geometry

--- a/src/base/lane.cc
+++ b/src/base/lane.cc
@@ -66,8 +66,6 @@ double Lane::ComputeDistanceToSegmentBoundary(bool to_left, double s) const {
 maliput::api::HBounds Lane::do_elevation_bounds(double, double) const { return elevation_bounds_; }
 
 maliput::math::Vector3 Lane::DoToBackendPosition(const maliput::api::LanePosition& lane_pos) const {
-  MALIPUT_THROW_UNLESS(lane_pos.s() >= lane_geometry_->p0());
-  MALIPUT_THROW_UNLESS(lane_pos.s() <= lane_geometry_->p1());
   return lane_geometry_->W(lane_pos.srh());
 }
 
@@ -124,8 +122,6 @@ void Lane::DoToSegmentPositionBackend(const maliput::math::Vector3& backend_pos,
 }
 
 maliput::api::Rotation Lane::DoGetOrientation(const maliput::api::LanePosition& lane_pos) const {
-  MALIPUT_THROW_UNLESS(lane_pos.s() >= lane_geometry_->p0());
-  MALIPUT_THROW_UNLESS(lane_pos.s() <= lane_geometry_->p1());
   const auto rpy = lane_geometry_->Orientation(lane_pos.srh());
   return maliput::api::Rotation::FromRpy(rpy.roll_angle(), rpy.pitch_angle(), rpy.yaw_angle());
 }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #41 

Relies on https://github.com/maliput/maliput/pull/529

## Summary
Use `maliput::common::RangeValidator` to validate the `p` parameter in the `LaneGeometry` methods.

-->>  p is asserted to be within [p0, p1] within a certain tolerance, then `p` is clamped to [p0+Epsilon, p1-Epsilon] to avoid falling outside the limits.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

action-ros-ci-repos-override: https://gist.githubusercontent.com/francocipollone/27c93e817a2e01f461afd4454bd9fadf/raw/9f9bc0a5adb4619eb02f396fe67749b092572f44/mailiput_sparse.repos
