### PR TITLE
Adds a adjacency checker for the builder.

### DIFF
--- a/include/maliput_sparse/geometry/utility/geometry.h
+++ b/include/maliput_sparse/geometry/utility/geometry.h
@@ -120,6 +120,23 @@ ClosestPointResult GetClosestPoint(const std::pair<maliput::math::Vector3, malip
 /// and the p coordinate in the LineString3d matching the closest point.
 ClosestPointResult GetClosestPoint(const LineString3d& line_string, const maliput::math::Vector3& xyz);
 
+/// Computes the distance between two LineString3d.
+/// The distance is calculated as the sum of distances between corresponding points between both line strings divided by
+/// the number of points. Some notes: 1 - The evaluation points to be used are the ones from the line string with more
+/// points. 2 - If the line strings have the same number of points, the evaluation points are the ones from the first
+/// line string. 3 - The closest point is calculated for each point in the line string with less points using #ref
+/// GetClosestPoint method.
+///
+/// This algorithm is not the most precise one, but it is the most intuitive one and for the expected use cases it is
+/// good enough.
+///
+/// TODO(#CreateIssue): Use Frechet distance algorithm instead.
+///
+/// @param lhs A LineString3d.
+/// @param rhs A LineString3d.
+/// @return The distance between the two line strings defined as above.
+double ComputeDistance(const LineString3d& lhs, const LineString3d& rhs);
+
 }  // namespace utility
 }  // namespace geometry
 }  // namespace maliput_sparse

--- a/include/maliput_sparse/parser/validator.h
+++ b/include/maliput_sparse/parser/validator.h
@@ -1,0 +1,115 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "maliput_sparse/parser/parser.h"
+
+namespace maliput_sparse {
+namespace parser {
+
+/// ValidatorOptions struct that contains the options for the Validator.
+struct ValidatorOptions {
+  /// Verifies adjacency for lanes in a segment.
+  bool lane_adjacency{true};
+};
+
+/// ValidatorConfig struct that contains the configuration for the Validator.
+struct ValidatorConfig {
+  double linear_tolerance{1e-12};
+};
+
+/// After parsing a road network, the Validator can be used to check for errors before
+/// creating a maliput::api::RoadNetwork via the maliput_sparse::loader::RoadNetworkLoader.
+/// The Validator can be configured to check for different types of errors and provide an interface to retrieve
+/// the errors found.
+/// The errors are stored in a vector of Error structs. The Error struct contains a message, the type of error, and the
+/// severity. It's on the user to decide how to handle the errors.
+class Validator {
+ public:
+  /// Error struct that contains the error message, type, and severity.
+  struct Error {
+    /// The type of error.
+    enum class Type {
+      kLaneAdjacency,
+    };
+    /// The severity of the error.
+    enum class Severity {
+      kWarning,
+      kError,
+    };
+
+    /// Equality operator for Error.
+    bool operator==(const Error& other) const;
+    /// Inequality operator for Error.
+    bool operator!=(const Error& other) const;
+
+    /// Message describing the error.
+    std::string message;
+    /// The type of error.
+    Type type;
+    /// The severity of the error.
+    Severity severity;
+  };
+
+  /// Constructor for Validator.
+  /// During construction, the Validator will perform the validation checks.
+  ////
+  /// @param parser The maliput_sparse::parser::Parser instance to validate.
+  /// @param options The maliput_sparse::parser::ValidatorOptions to use.
+  /// @param config The maliput_sparse::parser::ValidatorConfig to use.
+  Validator(const Parser* parser, const ValidatorOptions& options, const ValidatorConfig config);
+
+  /// Returns the errors found during validation.
+  const std::vector<Error>& GetErrors() const;
+
+ private:
+  // Helper functions for reporting errors.
+  // @param message The error message.
+  // @Param type The type of error.
+  // @Param severity The severity of the error.
+  void Report(const std::string& message, const Error::Type& type, const Error::Severity& severity);
+
+  // Method to validate lane adjacency.
+  // @param parser The maliput_sparse::parser::Parser instance to validate.
+  // @param config The maliput_sparse::parser::ValidatorConfig to use.
+  void ValidateLaneAdjacency(const Parser* parser, const ValidatorConfig config);
+
+  // Helper function to geometrically check lane adjacency.
+  void CheckAdjacency(const Lane& lane, const Lane& adjacent_lane, bool left, double tolerance);
+
+  // Holds the errors found during validation.
+  std::vector<Error> errors_;
+};
+
+}  // namespace parser
+}  // namespace maliput_sparse

--- a/include/maliput_sparse/parser/validator.h
+++ b/include/maliput_sparse/parser/validator.h
@@ -60,7 +60,8 @@ class Validator {
   struct Error {
     /// The type of error.
     enum class Type {
-      kLaneAdjacency,
+      kLogicalLaneAdjacency,
+      kGeometricalLaneAdjacency,
     };
     /// The severity of the error.
     enum class Severity {
@@ -87,29 +88,25 @@ class Validator {
   /// @param parser The maliput_sparse::parser::Parser instance to validate.
   /// @param options The maliput_sparse::parser::ValidatorOptions to use.
   /// @param config The maliput_sparse::parser::ValidatorConfig to use.
-  Validator(const Parser* parser, const ValidatorOptions& options, const ValidatorConfig config);
+  Validator(const Parser* parser, const ValidatorOptions& options, const ValidatorConfig& config);
 
   /// Returns the errors found during validation.
-  const std::vector<Error>& GetErrors() const;
+  std::vector<Error> operator()() const;
 
  private:
-  // Helper functions for reporting errors.
-  // @param message The error message.
-  // @Param type The type of error.
-  // @Param severity The severity of the error.
-  void Report(const std::string& message, const Error::Type& type, const Error::Severity& severity);
-
-  // Method to validate lane adjacency.
-  // @param parser The maliput_sparse::parser::Parser instance to validate.
-  // @param config The maliput_sparse::parser::ValidatorConfig to use.
-  void ValidateLaneAdjacency(const Parser* parser, const ValidatorConfig config);
-
-  // Helper function to geometrically check lane adjacency.
-  void CheckAdjacency(const Lane& lane, const Lane& adjacent_lane, bool left, double tolerance);
-
-  // Holds the errors found during validation.
-  std::vector<Error> errors_;
+  // The maliput_sparse::parser::Parser instance to validate.
+  const Parser* parser_{nullptr};
+  // The maliput_sparse::parser::ValidatorOptions to use.
+  const ValidatorOptions options_;
+  // The maliput_sparse::parser::ValidatorConfig to use.
+  const ValidatorConfig config_;
 };
+
+/// Validates lane adjacency.
+/// @param parser The maliput_sparse::parser::Parser instance to validate.
+/// @param config The maliput_sparse::parser::ValidatorConfig to use.
+/// @returns A vector of maliput_sparse::parser::Validator::Error.
+std::vector<Validator::Error> ValidateLaneAdjacency(const Parser* parser, const ValidatorConfig config);
 
 }  // namespace parser
 }  // namespace maliput_sparse

--- a/include/maliput_sparse/parser/validator.h
+++ b/include/maliput_sparse/parser/validator.h
@@ -102,11 +102,5 @@ class Validator {
   const ValidatorConfig config_;
 };
 
-/// Validates lane adjacency.
-/// @param parser The maliput_sparse::parser::Parser instance to validate.
-/// @param config The maliput_sparse::parser::ValidatorConfig to use.
-/// @returns A vector of maliput_sparse::parser::Validator::Error.
-std::vector<Validator::Error> ValidateLaneAdjacency(const Parser* parser, const ValidatorConfig config);
-
 }  // namespace parser
 }  // namespace maliput_sparse

--- a/src/geometry/utility/geometry.cc
+++ b/src/geometry/utility/geometry.cc
@@ -60,6 +60,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <numeric>
 
 namespace maliput_sparse {
 namespace geometry {
@@ -377,12 +378,12 @@ ClosestPointResult GetClosestPoint(const LineString3d& line_string, const malipu
 double ComputeDistance(const LineString3d& lhs, const LineString3d& rhs) {
   const LineString3d& base_ls = rhs.size() > lhs.size() ? rhs : lhs;
   const LineString3d& other_ls = rhs.size() > lhs.size() ? lhs : rhs;
-  double sum_distances{};
-  for (const auto& base_point : base_ls) {
-    const auto closest_point_res = GetClosestPoint(other_ls, base_point);
-    sum_distances += closest_point_res.distance;
-  }
-  return sum_distances / base_ls.size();
+  const double sum_distances =
+      std::accumulate(base_ls.begin(), base_ls.end(), 0.0, [&other_ls](double sum, const auto& base_point) {
+        const auto closest_point_res = GetClosestPoint(other_ls, base_point);
+        return sum + closest_point_res.distance;
+      });
+  return sum_distances / static_cast<double>(base_ls.size());
 }
 
 }  // namespace utility

--- a/src/geometry/utility/geometry.cc
+++ b/src/geometry/utility/geometry.cc
@@ -374,6 +374,17 @@ ClosestPointResult GetClosestPoint(const LineString3d& line_string, const malipu
   return result;
 }
 
+double ComputeDistance(const LineString3d& lhs, const LineString3d& rhs) {
+  const LineString3d& base_ls = rhs.size() > lhs.size() ? rhs : lhs;
+  const LineString3d& other_ls = rhs.size() > lhs.size() ? lhs : rhs;
+  double sum_distances{};
+  for (const auto& base_point : base_ls) {
+    const auto closest_point_res = GetClosestPoint(other_ls, base_point);
+    sum_distances += closest_point_res.distance;
+  }
+  return sum_distances / base_ls.size();
+}
+
 }  // namespace utility
 }  // namespace geometry
 }  // namespace maliput_sparse

--- a/src/loader/road_geometry_loader.cc
+++ b/src/loader/road_geometry_loader.cc
@@ -59,15 +59,17 @@ RoadGeometryLoader::RoadGeometryLoader(std::unique_ptr<parser::Parser> parser,
 
 std::unique_ptr<const maliput::api::RoadGeometry> RoadGeometryLoader::operator()() {
   // Validates the parsed data before building the RoadGeometry.
-  const auto errors = parser::Validator(parser_.get(), parser::ValidatorOptions{true},
-                                        parser::ValidatorConfig{builder_configuration_.linear_tolerance})();
+  const auto errors = parser::Validator(
+      parser_.get(),
+      {parser::Validator::Type::kLogicalLaneAdjacency, parser::Validator::Type::kGeometricalLaneAdjacency},
+      parser::ValidatorConfig{builder_configuration_.linear_tolerance})();
   for (const auto& error : errors) {
     switch (error.severity) {
       case parser::Validator::Error::Severity::kError:
-        maliput::log()->error("{}", error.message);
+        maliput::log()->error("[{}] {}", error.type, error.message);
         break;
       case parser::Validator::Error::Severity::kWarning:
-        maliput::log()->warn("{}", error.message);
+        maliput::log()->warn("[{}] {}", error.type, error.message);
         break;
       default:
         MALIPUT_THROW_MESSAGE("Unknown parser::Validator::Error::Severity value: " + static_cast<int>(error.severity));

--- a/src/loader/road_geometry_loader.cc
+++ b/src/loader/road_geometry_loader.cc
@@ -29,7 +29,10 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "maliput_sparse/loader/road_geometry_loader.h"
 
+#include <maliput/common/logger.h>
+
 #include "maliput_sparse/builder/builder.h"
+#include "maliput_sparse/parser/validator.h"
 
 namespace maliput_sparse {
 namespace loader {
@@ -55,6 +58,27 @@ RoadGeometryLoader::RoadGeometryLoader(std::unique_ptr<parser::Parser> parser,
 }
 
 std::unique_ptr<const maliput::api::RoadGeometry> RoadGeometryLoader::operator()() {
+  // Validates the parsed data before building the RoadGeometry.
+  const parser::Validator validator(parser_.get(), parser::ValidatorOptions{true},
+                                    parser::ValidatorConfig{builder_configuration_.linear_tolerance});
+  const auto errors = validator.GetErrors();
+  for (const auto& error : errors) {
+    if (error.severity == parser::Validator::Error::Severity::kError) {
+      maliput::log()->error("{}", error.message);
+    }
+    if (error.severity == parser::Validator::Error::Severity::kWarning) {
+      maliput::log()->warn("{}", error.message);
+    }
+  }
+
+  if (std::find_if(errors.begin(), errors.end(), [](const parser::Validator::Error& error) {
+        return error.severity == parser::Validator::Error::Severity::kError;
+      }) != errors.end()) {
+    MALIPUT_THROW_MESSAGE("Errors(" + std::to_string(static_cast<int>(errors.size())) +
+                          ") found during validation. Aborting.");
+  }
+
+  // Builds the RoadGeometry.
   const std::unordered_map<parser::Junction::Id, parser::Junction>& junctions = parser_->GetJunctions();
   const std::vector<parser::Connection>& connections = parser_->GetConnections();
 

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -4,6 +4,7 @@
 add_library(parser
   connection.cc
   lane.cc
+  validator.cc
 )
 
 add_library(maliput_sparse::parser ALIAS parser)
@@ -23,6 +24,7 @@ target_include_directories(
 target_link_libraries(parser
    PRIVATE
     maliput::common
+    maliput_sparse::geometry
 )
 
 install(TARGETS parser

--- a/src/parser/validation_methods.h
+++ b/src/parser/validation_methods.h
@@ -39,9 +39,11 @@ namespace parser {
 
 /// Validates lane adjacency.
 /// @param parser The maliput_sparse::parser::Parser instance to validate.
+/// @param validate_geometric_adjacency Whether to validate geometric adjacency.
 /// @param config The maliput_sparse::parser::ValidatorConfig to use.
 /// @returns A vector of maliput_sparse::parser::Validator::Error.
-std::vector<Validator::Error> ValidateLaneAdjacency(const Parser* parser, const ValidatorConfig config);
+std::vector<Validator::Error> ValidateLaneAdjacency(const Parser* parser, const bool& validate_geometric_adjacency,
+                                                    const ValidatorConfig config);
 
 }  // namespace parser
 }  // namespace maliput_sparse

--- a/src/parser/validation_methods.h
+++ b/src/parser/validation_methods.h
@@ -1,0 +1,47 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <vector>
+
+#include "maliput_sparse/parser/parser.h"
+#include "maliput_sparse/parser/validator.h"
+
+namespace maliput_sparse {
+namespace parser {
+
+/// Validates lane adjacency.
+/// @param parser The maliput_sparse::parser::Parser instance to validate.
+/// @param config The maliput_sparse::parser::ValidatorConfig to use.
+/// @returns A vector of maliput_sparse::parser::Validator::Error.
+std::vector<Validator::Error> ValidateLaneAdjacency(const Parser* parser, const ValidatorConfig config);
+
+}  // namespace parser
+}  // namespace maliput_sparse

--- a/src/parser/validation_methods.h
+++ b/src/parser/validation_methods.h
@@ -42,8 +42,8 @@ namespace parser {
 /// @param validate_geometric_adjacency Whether to validate geometric adjacency.
 /// @param config The maliput_sparse::parser::ValidatorConfig to use.
 /// @returns A vector of maliput_sparse::parser::Validator::Error.
-std::vector<Validator::Error> ValidateLaneAdjacency(const Parser* parser, const bool& validate_geometric_adjacency,
-                                                    const ValidatorConfig config);
+std::vector<Validator::Error> ValidateLaneAdjacency(const Parser* parser, bool validate_geometric_adjacency,
+                                                    const ValidatorConfig& config);
 
 }  // namespace parser
 }  // namespace maliput_sparse

--- a/src/parser/validator.cc
+++ b/src/parser/validator.cc
@@ -96,8 +96,8 @@ std::vector<Validator::Error> Validator::operator()() const {
   return errors;
 }
 
-std::vector<Validator::Error> ValidateLaneAdjacency(const Parser* parser, const bool& validate_geometric_adjacency,
-                                                    const ValidatorConfig config) {
+std::vector<Validator::Error> ValidateLaneAdjacency(const Parser* parser, bool validate_geometric_adjacency,
+                                                    const ValidatorConfig& config) {
   std::vector<Validator::Error> errors;
   auto evaluate = [&errors](bool condition, const std::string& message, const Validator::Type& error_type) {
     if (condition) {

--- a/src/parser/validator.cc
+++ b/src/parser/validator.cc
@@ -43,35 +43,41 @@ namespace {
 static constexpr bool kLeft{true};
 static constexpr bool kRight{!kLeft};
 
-}  // namespace
+// Helper function to geometrically check lane adjacency.
+// It relies on geometry::utility::ComputeDistance to compute the distance between the two adjacent line strings.
+// Returns true if the lanes are adjacent under certain tolerance, false otherwise.
 
-Validator::Validator(const Parser* parser, const ValidatorOptions& options, const ValidatorConfig config) {
-  MALIPUT_THROW_UNLESS(parser);
-  if (options.lane_adjacency) {
-    ValidateLaneAdjacency(parser, config);
-  }
-}
-
-const std::vector<Validator::Error>& Validator::GetErrors() const { return errors_; }
-
-void Validator::CheckAdjacency(const Lane& lane, const Lane& adjacent_lane, bool left, double tolerance) {
+bool AreAdjacent(const Lane& lane, const Lane& adjacent_lane, bool left, double tolerance) {
   const auto line_string_a = left ? lane.left : lane.right;
   const auto line_string_b = left ? adjacent_lane.right : adjacent_lane.left;
   const double distance = geometry::utility::ComputeDistance(line_string_a, line_string_b);
-  if (distance > tolerance) {
-    const std::string msg{"Lane " + lane.id + " and lane " + adjacent_lane.id +
-                          " are not adjacent under the tolerance " + std::to_string(tolerance) +
-                          ". (distance: " + std::to_string(distance) + ")"};
-    Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
+  return distance <= tolerance;
+}
+
+}  // namespace
+
+Validator::Validator(const Parser* parser, const ValidatorOptions& options, const ValidatorConfig& config)
+    : parser_{parser}, options_{options}, config_{config} {
+  MALIPUT_THROW_UNLESS(parser_);
+}
+
+std::vector<Validator::Error> Validator::operator()() const {
+  std::vector<Validator::Error> errors;
+  if (options_.lane_adjacency) {
+    const auto lane_adjacency_errors = ValidateLaneAdjacency(parser_, config_);
+    errors.insert(errors.end(), lane_adjacency_errors.begin(), lane_adjacency_errors.end());
   }
+  return errors;
 }
 
-void Validator::Report(const std::string& message, const Validator::Error::Type& type,
-                       const Validator::Error::Severity& severity) {
-  errors_.push_back(Validator::Error{message, type, severity});
-}
-
-void Validator::ValidateLaneAdjacency(const Parser* parser, const ValidatorConfig config) {
+std::vector<Validator::Error> ValidateLaneAdjacency(const Parser* parser, const ValidatorConfig config) {
+  std::vector<Validator::Error> errors;
+  auto evaluate = [&errors](bool condition, const std::string& message, const Validator::Error::Type& error_type) {
+    if (condition) {
+      errors.push_back({message, error_type, Validator::Error::Severity::kError});
+    }
+    return condition;
+  };
   const auto junctions = parser->GetJunctions();
   for (const auto junction : junctions) {
     for (const auto segment : junction.second.segments) {
@@ -82,130 +88,122 @@ void Validator::ValidateLaneAdjacency(const Parser* parser, const ValidatorConfi
         const Lane& lane = lanes[idx];
 
         // Note: The following code is a bit repetitive for left and right adjacency checks, but it is easier to read
-        // and understand. Check right adjacency <--------------------------------------------------
+        // and understand.
+        //
+        // Check right adjacency <--------------------------------------------------
         if (lane.right_lane_id) {
           // Check if there is a idx to the right.
-          if (idx == 0) {
-            // Error.
-            const std::string msg{"Wrong ordering of lanes: Lane " + lane.id + " has a right lane id (" +
-                                  lane.right_lane_id.value() + ") but is the first lane in the segment " +
-                                  segment.first + "."};
-            Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
-          }
+          evaluate(idx == 0,
+                   {"Wrong ordering of lanes: Lane " + lane.id + " has a right lane id (" + lane.right_lane_id.value() +
+                    ") but is the first lane in the segment " + segment.first + "."},
+                   Validator::Error::Type::kLogicalLaneAdjacency);
           // Check if right lane id is in the same segment
           const auto adj_lane_it = std::find_if(lanes.begin(), lanes.end(), [&lane](const Lane& lane_it) {
             return lane.right_lane_id.value() == lane_it.id;
           });
           if (adj_lane_it == lanes.end()) {
             // Error.
-            const std::string msg{"Adjacent lane isn't part of the segment: Lane " + lane.id +
-                                  " has a right lane id (" + lane.right_lane_id.value() +
-                                  ") that is not part of the segment " + segment.first + "."};
-            Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
+            evaluate(true,
+                     {"Adjacent lane isn't part of the segment: Lane " + lane.id + " has a right lane id (" +
+                      lane.right_lane_id.value() + ") that is not part of the segment " + segment.first + "."},
+                     Validator::Error::Type::kLogicalLaneAdjacency);
           } else {
             // Check if right lane id has the lane id as left lane id.
             if (adj_lane_it->left_lane_id) {
-              if (adj_lane_it->left_lane_id.value() != lane.id) {
-                // Error.
-                const std::string msg{"Wrong ordering of lanes: Lane " + lane.id + " has a right lane id (" +
-                                      lane.right_lane_id.value() + ") that has a left lane id (" +
-                                      adj_lane_it->left_lane_id.value() + ") that is not the lane " + lane.id + "."};
-                Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
-              }
+              evaluate(adj_lane_it->left_lane_id.value() != lane.id,
+                       {"Wrong ordering of lanes: Lane " + lane.id + " has a right lane id (" +
+                        lane.right_lane_id.value() + ") that has a left lane id (" + adj_lane_it->left_lane_id.value() +
+                        ") that is not the lane " + lane.id + "."},
+                       Validator::Error::Type::kLogicalLaneAdjacency);
+
             } else {
-              // Error.
-              const std::string msg{"Wrong ordering of lanes: Lane " + lane.id + " has a right lane id (" +
-                                    lane.right_lane_id.value() + ") that has no left lane id."};
-              Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
+              evaluate(true,
+                       {"Wrong ordering of lanes: Lane " + lane.id + " has a right lane id (" +
+                        lane.right_lane_id.value() + ") that has no left lane id."},
+                       Validator::Error::Type::kLogicalLaneAdjacency);
             }
 
             // Check geometrical adjacency.
-            CheckAdjacency(lane, *adj_lane_it, kRight, config.linear_tolerance);
+            evaluate(!AreAdjacent(lane, *adj_lane_it, kRight, config.linear_tolerance),
+                     {"Lane " + lane.id + " and lane " + adj_lane_it->id + " are not adjacent under the tolerance " +
+                      std::to_string(config.linear_tolerance) + "."},
+                     Validator::Error::Type::kGeometricalLaneAdjacency);
           }
 
           // Check if idx - 1 lane is the right lane id.
-          if ((idx - 1 >= 0) && (lanes[idx - 1].id != lane.right_lane_id.value())) {
-            // Error.
-            const std::string msg{"Wrong ordering of lanes: Lane " + lane.id + " has a right lane id (" +
-                                  lane.right_lane_id.value() + ") that is not the previous lane in the segment " +
-                                  segment.first + "."};
-            Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
-          }
+          evaluate((idx - 1 >= 0) && (lanes[idx - 1].id != lane.right_lane_id.value()),
+                   {"Wrong ordering of lanes: Lane " + lane.id + " has a right lane id (" + lane.right_lane_id.value() +
+                    ") that is not the previous lane in the segment " + segment.first + "."},
+                   Validator::Error::Type::kLogicalLaneAdjacency);
 
         } else {
           // Check if idx is the first lane in the segment.
-          if (idx != 0) {
-            // Error.
-            const std::string msg{"Wrong ordering of lanes: Lane " + lane.id +
-                                  " has no right lane id but it isn't the first lane in the segment " + segment.first +
-                                  "."};
-            Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
-          }
+          evaluate(idx != 0,
+                   {"Wrong ordering of lanes: Lane " + lane.id +
+                    " has no right lane id but it isn't the first lane in the segment " + segment.first + "."},
+                   Validator::Error::Type::kLogicalLaneAdjacency);
         }
 
         // Check left adjacency <--------------------------------------------------
         if (lane.left_lane_id) {
           // Check if there is a idx to the left.
-          if (idx == static_cast<int>(lanes.size()) - 1) {
-            // Error.
-            const std::string msg{"Wrong ordering of lanes: Lane " + lane.id + " has a left lane id (" +
-                                  lane.left_lane_id.value() + ") but is the last lane in the segment " + segment.first +
-                                  "."};
-            Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
-          }
+          evaluate(idx == static_cast<int>(lanes.size()) - 1,
+                   {"Wrong ordering of lanes: Lane " + lane.id + " has a left lane id (" + lane.left_lane_id.value() +
+                    ") but is the last lane in the segment " + segment.first + "."},
+                   Validator::Error::Type::kLogicalLaneAdjacency);
+
           // Check if left lane id is in the same segment
           const auto adj_lane_it = std::find_if(lanes.begin(), lanes.end(), [&lane](const Lane& lane_it) {
             return lane.left_lane_id.value() == lane_it.id;
           });
           if (adj_lane_it == lanes.end()) {
-            // Error.
-            const std::string msg{"Adjacent lane isn't part of the segment: Lane " + lane.id + " has a left lane id (" +
-                                  lane.left_lane_id.value() + ") that is not part of the segment " + segment.first +
-                                  "."};
-            Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
+            evaluate(true,
+                     {"Adjacent lane isn't part of the segment: Lane " + lane.id + " has a left lane id (" +
+                      lane.left_lane_id.value() + ") that is not part of the segment " + segment.first + "."},
+                     Validator::Error::Type::kLogicalLaneAdjacency);
           } else {
             // Check if left lane id has the lane id as right lane id.
             if (adj_lane_it->right_lane_id) {
-              if (adj_lane_it->right_lane_id.value() != lane.id) {
-                // Error.
-                const std::string msg{"Wrong ordering of lanes: Lane " + lane.id + " has a left lane id (" +
-                                      lane.left_lane_id.value() + ") that has a right lane id (" +
-                                      adj_lane_it->right_lane_id.value() + ") that is not the lane " + lane.id + "."};
-                Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
-              }
+              evaluate(adj_lane_it->right_lane_id.value() != lane.id,
+                       {"Wrong ordering of lanes: Lane " + lane.id + " has a left lane id (" +
+                        lane.left_lane_id.value() + ") that has a right lane id (" +
+                        adj_lane_it->right_lane_id.value() + ") that is not the lane " + lane.id + "."},
+                       Validator::Error::Type::kLogicalLaneAdjacency);
             } else {
               // Error.
-              const std::string msg{"Wrong ordering of lanes: Lane " + lane.id + " has a left lane id (" +
-                                    lane.left_lane_id.value() + ") that has no right lane id."};
-              Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
+              evaluate(true,
+                       {"Wrong ordering of lanes: Lane " + lane.id + " has a left lane id (" +
+                        lane.left_lane_id.value() + ") that has no right lane id."},
+                       Validator::Error::Type::kLogicalLaneAdjacency);
             }
 
             // Check geometrical adjacency.
-            CheckAdjacency(lane, *adj_lane_it, kLeft, config.linear_tolerance);
+            evaluate(!AreAdjacent(lane, *adj_lane_it, kLeft, config.linear_tolerance),
+                     {"Lane " + lane.id + " and lane " + adj_lane_it->id + " are not adjacent under the tolerance " +
+                      std::to_string(config.linear_tolerance) + "."},
+                     Validator::Error::Type::kGeometricalLaneAdjacency);
           }
 
           // Check if idx + 1 lane is the left lane id.
           if ((idx + 1 <= static_cast<int>(lanes.size()) - 1) && (lanes[idx + 1].id != lane.left_lane_id.value())) {
             // Error.
-            const std::string msg{"Wrong ordering of lanes: Lane " + lane.id + " has a left lane id (" +
-                                  lane.left_lane_id.value() + ") that is not the next lane in the segment " +
-                                  segment.first + "."};
-            Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
+            evaluate(true,
+                     {"Wrong ordering of lanes: Lane " + lane.id + " has a left lane id (" + lane.left_lane_id.value() +
+                      ") that is not the next lane in the segment " + segment.first + "."},
+                     Validator::Error::Type::kLogicalLaneAdjacency);
           }
 
         } else {
           // Check if idx is the last lane in the segment.
-          if (idx != static_cast<int>(lanes.size()) - 1) {
-            // Error.
-            const std::string msg{"Wrong ordering of lanes: Lane " + lane.id +
-                                  " has no left lane id but it isn't the last lane in the segment " + segment.first +
-                                  "."};
-            Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
-          }
+          evaluate(idx != static_cast<int>(lanes.size()) - 1,
+                   {"Wrong ordering of lanes: Lane " + lane.id +
+                    " has no left lane id but it isn't the last lane in the segment " + segment.first + "."},
+                   Validator::Error::Type::kLogicalLaneAdjacency);
         }
       }
     }
   }
+  return errors;
 }
 
 bool Validator::Error::operator==(const Error& other) const {

--- a/src/parser/validator.cc
+++ b/src/parser/validator.cc
@@ -1,0 +1,218 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "maliput_sparse/parser/validator.h"
+
+#include "maliput_sparse/geometry/utility/geometry.h"
+#include "maliput_sparse/parser/junction.h"
+#include "maliput_sparse/parser/lane.h"
+#include "maliput_sparse/parser/segment.h"
+
+namespace maliput_sparse {
+namespace parser {
+
+namespace {
+
+// Convenient constant for indicating left or right.
+static constexpr bool kLeft{true};
+static constexpr bool kRight{!kLeft};
+
+}  // namespace
+
+Validator::Validator(const Parser* parser, const ValidatorOptions& options, const ValidatorConfig config) {
+  MALIPUT_THROW_UNLESS(parser);
+  if (options.lane_adjacency) {
+    ValidateLaneAdjacency(parser, config);
+  }
+}
+
+const std::vector<Validator::Error>& Validator::GetErrors() const { return errors_; }
+
+void Validator::CheckAdjacency(const Lane& lane, const Lane& adjacent_lane, bool left, double tolerance) {
+  const auto line_string_a = left ? lane.left : lane.right;
+  const auto line_string_b = left ? adjacent_lane.right : adjacent_lane.left;
+  const double distance = geometry::utility::ComputeDistance(line_string_a, line_string_b);
+  if (distance > tolerance) {
+    const std::string msg{"Lane " + lane.id + " and lane " + adjacent_lane.id +
+                          " are not adjacent under the tolerance " + std::to_string(tolerance) +
+                          ". (distance: " + std::to_string(distance) + ")"};
+    Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
+  }
+}
+
+void Validator::Report(const std::string& message, const Validator::Error::Type& type,
+                       const Validator::Error::Severity& severity) {
+  errors_.push_back(Validator::Error{message, type, severity});
+}
+
+void Validator::ValidateLaneAdjacency(const Parser* parser, const ValidatorConfig config) {
+  const auto junctions = parser->GetJunctions();
+  for (const auto junction : junctions) {
+    for (const auto segment : junction.second.segments) {
+      const std::vector<Lane>& lanes = segment.second.lanes;
+      // Iterates lanes from right to left.
+      // | idx=N-1 | idx=3 | idx=2 | idx=1 | idx=0 |
+      for (int idx{}; idx < static_cast<int>(lanes.size()); ++idx) {
+        const Lane& lane = lanes[idx];
+
+        // Note: The following code is a bit repetitive for left and right adjacency checks, but it is easier to read
+        // and understand. Check right adjacency <--------------------------------------------------
+        if (lane.right_lane_id) {
+          // Check if there is a idx to the right.
+          if (idx == 0) {
+            // Error.
+            const std::string msg{"Wrong ordering of lanes: Lane " + lane.id + " has a right lane id (" +
+                                  lane.right_lane_id.value() + ") but is the first lane in the segment " +
+                                  segment.first + "."};
+            Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
+          }
+          // Check if right lane id is in the same segment
+          const auto adj_lane_it = std::find_if(lanes.begin(), lanes.end(), [&lane](const Lane& lane_it) {
+            return lane.right_lane_id.value() == lane_it.id;
+          });
+          if (adj_lane_it == lanes.end()) {
+            // Error.
+            const std::string msg{"Adjacent lane isn't part of the segment: Lane " + lane.id +
+                                  " has a right lane id (" + lane.right_lane_id.value() +
+                                  ") that is not part of the segment " + segment.first + "."};
+            Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
+          } else {
+            // Check if right lane id has the lane id as left lane id.
+            if (adj_lane_it->left_lane_id) {
+              if (adj_lane_it->left_lane_id.value() != lane.id) {
+                // Error.
+                const std::string msg{"Wrong ordering of lanes: Lane " + lane.id + " has a right lane id (" +
+                                      lane.right_lane_id.value() + ") that has a left lane id (" +
+                                      adj_lane_it->left_lane_id.value() + ") that is not the lane " + lane.id + "."};
+                Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
+              }
+            } else {
+              // Error.
+              const std::string msg{"Wrong ordering of lanes: Lane " + lane.id + " has a right lane id (" +
+                                    lane.right_lane_id.value() + ") that has no left lane id."};
+              Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
+            }
+
+            // Check geometrical adjacency.
+            CheckAdjacency(lane, *adj_lane_it, kRight, config.linear_tolerance);
+          }
+
+          // Check if idx - 1 lane is the right lane id.
+          if ((idx - 1 >= 0) && (lanes[idx - 1].id != lane.right_lane_id.value())) {
+            // Error.
+            const std::string msg{"Wrong ordering of lanes: Lane " + lane.id + " has a right lane id (" +
+                                  lane.right_lane_id.value() + ") that is not the previous lane in the segment " +
+                                  segment.first + "."};
+            Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
+          }
+
+        } else {
+          // Check if idx is the first lane in the segment.
+          if (idx != 0) {
+            // Error.
+            const std::string msg{"Wrong ordering of lanes: Lane " + lane.id +
+                                  " has no right lane id but it isn't the first lane in the segment " + segment.first +
+                                  "."};
+            Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
+          }
+        }
+
+        // Check left adjacency <--------------------------------------------------
+        if (lane.left_lane_id) {
+          // Check if there is a idx to the left.
+          if (idx == static_cast<int>(lanes.size()) - 1) {
+            // Error.
+            const std::string msg{"Wrong ordering of lanes: Lane " + lane.id + " has a left lane id (" +
+                                  lane.left_lane_id.value() + ") but is the last lane in the segment " + segment.first +
+                                  "."};
+            Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
+          }
+          // Check if left lane id is in the same segment
+          const auto adj_lane_it = std::find_if(lanes.begin(), lanes.end(), [&lane](const Lane& lane_it) {
+            return lane.left_lane_id.value() == lane_it.id;
+          });
+          if (adj_lane_it == lanes.end()) {
+            // Error.
+            const std::string msg{"Adjacent lane isn't part of the segment: Lane " + lane.id + " has a left lane id (" +
+                                  lane.left_lane_id.value() + ") that is not part of the segment " + segment.first +
+                                  "."};
+            Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
+          } else {
+            // Check if left lane id has the lane id as right lane id.
+            if (adj_lane_it->right_lane_id) {
+              if (adj_lane_it->right_lane_id.value() != lane.id) {
+                // Error.
+                const std::string msg{"Wrong ordering of lanes: Lane " + lane.id + " has a left lane id (" +
+                                      lane.left_lane_id.value() + ") that has a right lane id (" +
+                                      adj_lane_it->right_lane_id.value() + ") that is not the lane " + lane.id + "."};
+                Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
+              }
+            } else {
+              // Error.
+              const std::string msg{"Wrong ordering of lanes: Lane " + lane.id + " has a left lane id (" +
+                                    lane.left_lane_id.value() + ") that has no right lane id."};
+              Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
+            }
+
+            // Check geometrical adjacency.
+            CheckAdjacency(lane, *adj_lane_it, kLeft, config.linear_tolerance);
+          }
+
+          // Check if idx + 1 lane is the left lane id.
+          if ((idx + 1 <= static_cast<int>(lanes.size()) - 1) && (lanes[idx + 1].id != lane.left_lane_id.value())) {
+            // Error.
+            const std::string msg{"Wrong ordering of lanes: Lane " + lane.id + " has a left lane id (" +
+                                  lane.left_lane_id.value() + ") that is not the next lane in the segment " +
+                                  segment.first + "."};
+            Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
+          }
+
+        } else {
+          // Check if idx is the last lane in the segment.
+          if (idx != static_cast<int>(lanes.size()) - 1) {
+            // Error.
+            const std::string msg{"Wrong ordering of lanes: Lane " + lane.id +
+                                  " has no left lane id but it isn't the last lane in the segment " + segment.first +
+                                  "."};
+            Report(msg, Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError);
+          }
+        }
+      }
+    }
+  }
+}
+
+bool Validator::Error::operator==(const Error& other) const {
+  return message == other.message && type == other.type && severity == other.severity;
+}
+
+bool Validator::Error::operator!=(const Error& other) const { return !(*this == other); }
+
+}  // namespace parser
+}  // namespace maliput_sparse

--- a/test/geometry/utility/geometry_test.cc
+++ b/test/geometry/utility/geometry_test.cc
@@ -504,6 +504,47 @@ TEST_P(GetClosestPointLineStringTest, Test) {
 INSTANTIATE_TEST_CASE_P(GetClosestPointLineStringTestGroup, GetClosestPointLineStringTest,
                         ::testing::ValuesIn(GetClosestPointLineStringTestCases()));
 
+struct ComputeDistanceTestCase {
+  LineString3d lhs;
+  LineString3d rhs;
+  double expected_distance{0.};
+};
+
+std::vector<ComputeDistanceTestCase> ComputeDistanceTestCases() {
+  return {
+      {
+          LineString3d{{0., 0., 0.}, {10., 0., 0.}} /* lhs */, LineString3d{{0., 0., 0.}, {10., 0., 0.}} /* rhs */,
+          0. /* expected_distance */
+      },
+      {
+          LineString3d{{0., 5., 0.}, {10., 5., 0.}} /* lhs */, LineString3d{{0., 0., 0.}, {10., 0., 0.}} /* rhs */,
+          5. /* expected_distance */
+      },
+      {
+          LineString3d{{0., 5., 0.}, {10., 5., 0.}} /* lhs */,
+          LineString3d{{0., 0., 0.}, {2., 0., 0.}, {4., 0., 0.}, {6., 0., 0.}, {8., 0., 0.}, {10., 0., 0.}} /* rhs */,
+          5. /* expected_distance */
+      },
+      {
+          LineString3d{{0., 0., 0.}, {2., 0., 0.}, {4., 0., 0.}, {6., 0., 0.}, {8., 0., 0.}, {10., 0., 0.}} /* lhs */,
+          LineString3d{{0., 5., 0.}, {10., 5., 0.}} /* rhs */, 5. /* expected_distance */
+      },
+  };
+}
+
+class ComputeDistanceTest : public ::testing::TestWithParam<ComputeDistanceTestCase> {
+ public:
+  static constexpr double kTolerance{1e-12};
+  ComputeDistanceTestCase case_ = GetParam();
+};
+
+TEST_P(ComputeDistanceTest, Test) {
+  const auto dut = ComputeDistance(case_.lhs, case_.rhs);
+  EXPECT_NEAR(case_.expected_distance, dut, kTolerance);
+}
+
+INSTANTIATE_TEST_CASE_P(ComputeDistanceTestGroup, ComputeDistanceTest, ::testing::ValuesIn(ComputeDistanceTestCases()));
+
 }  // namespace
 }  // namespace test
 }  // namespace utility

--- a/test/parser/CMakeLists.txt
+++ b/test/parser/CMakeLists.txt
@@ -1,5 +1,6 @@
 ament_add_gtest(lane_parser_test lane_test.cc)
 ament_add_gtest(segment_parser_test segment_test.cc)
+ament_add_gtest(validator_test validator_test.cc)
 
 macro(add_dependencies_to_test target)
 if (TARGET ${target})
@@ -20,5 +21,6 @@ if (TARGET ${target})
     endif()
 endmacro()
 
+add_dependencies_to_test(validator_test)
 add_dependencies_to_test(lane_parser_test)
 add_dependencies_to_test(segment_parser_test)

--- a/test/parser/validator_test.cc
+++ b/test/parser/validator_test.cc
@@ -35,6 +35,7 @@
 #include <maliput/common/assertion_error.h>
 
 #include "maliput_sparse/parser/parser.h"
+#include "parser/validation_methods.h"
 
 namespace maliput_sparse {
 namespace parser {

--- a/test/parser/validator_test.cc
+++ b/test/parser/validator_test.cc
@@ -32,6 +32,7 @@
 #include <string>
 
 #include <gtest/gtest.h>
+#include <maliput/common/assertion_error.h>
 
 #include "maliput_sparse/parser/parser.h"
 
@@ -69,6 +70,36 @@ class ValidatorTest : public ::testing::Test {
     return MockParser({{junction.id, junction}}, {});
   }
 
+ protected:
+  const Lane wrong_adj_lane{CreateLane("0", LineString3d{{1., 1., 1.}, {10., 1., 1.}},
+                                       LineString3d{{1., -1., 1.}, {10., -1., 1.}}, {"23123"}, std::nullopt, {}, {})};
+};
+
+TEST_F(ValidatorTest, InvalidParser) {
+  EXPECT_THROW(Validator(nullptr, {}, ValidatorConfig{1e-3}), maliput::common::assertion_error);
+}
+
+TEST_F(ValidatorTest, AllOptionsDisabled) {
+  ValidatorOptions options;
+  options.lane_adjacency = false;
+  const MockParser parser = CreateMockParser({wrong_adj_lane});
+  const auto errors = Validator(&parser, options, ValidatorConfig{1e-3})();
+  ASSERT_EQ(0., errors.size());
+}
+
+TEST_F(ValidatorTest, LaneAdjacencyOption) {
+  ValidatorOptions options;
+  options.lane_adjacency = true;
+  const MockParser parser = CreateMockParser({wrong_adj_lane});
+  const auto errors = Validator(&parser, options, ValidatorConfig{1e-3})();
+  ASSERT_NE(0., errors.size());
+  for (const auto& error : errors) {
+    EXPECT_TRUE(error.type == Validator::Error::Type::kLogicalLaneAdjacency);
+  }
+}
+
+class ValidateLaneAdjacencyTest : public ValidatorTest {
+ public:
   const Lane lane_0 = CreateLane("0", LineString3d{{1., 1., 1.}, {10., 1., 1.}},
                                  LineString3d{{1., -1., 1.}, {10., -1., 1.}}, {"1"}, std::nullopt, {}, {});
   const Lane lane_1 = CreateLane("1", LineString3d{{1., 3., 1.}, {10., 3., 1.}},
@@ -79,74 +110,71 @@ class ValidatorTest : public ::testing::Test {
                                  LineString3d{{1., 5., 1.}, {10., 5., 1.}}, std::nullopt, {"2"}, {}, {});
 };
 
-TEST_F(ValidatorTest, NoErrors) {
+TEST_F(ValidateLaneAdjacencyTest, NoErrors) {
   const Segment segment{"segment", {lane_0, lane_1, lane_2, lane_3}};
   const Junction junction{"junction", {{segment.id, segment}}};
   const MockParser parser({{junction.id, junction}}, {});
-  const Validator dut(&parser, ValidatorOptions{true}, ValidatorConfig{1e-3});
-  const auto errors = dut.GetErrors();
+  const auto errors = ValidateLaneAdjacency(&parser, ValidatorConfig{1e-3});
   EXPECT_EQ(0., errors.size());
 }
 
-TEST_F(ValidatorTest, NoValidRightLaneInTheSegment) {
+TEST_F(ValidateLaneAdjacencyTest, NoValidRightLaneInTheSegment) {
   const std::vector<Validator::Error> expected_errors{
       {"Wrong ordering of lanes: Lane 1 has a left lane id (2) that has a right lane id (41856) that is not the lane "
        "1.",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+       Validator::Error::Type::kLogicalLaneAdjacency, Validator::Error::Severity::kError},
       {"Adjacent lane isn't part of the segment: Lane 2 has a right lane id (41856) that is not part of the segment "
        "segment.",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+       Validator::Error::Type::kLogicalLaneAdjacency, Validator::Error::Severity::kError},
       {"Wrong ordering of lanes: Lane 2 has a right lane id (41856) that is not the previous lane in the segment "
        "segment.",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+       Validator::Error::Type::kLogicalLaneAdjacency, Validator::Error::Severity::kError},
   };
   Lane lane_2_no_valid_right_id{lane_2};
   lane_2_no_valid_right_id.right_lane_id = "41856";
   const Segment segment{"segment", {lane_0, lane_1, lane_2_no_valid_right_id, lane_3}};
   const Junction junction{"junction", {{segment.id, segment}}};
   const MockParser parser({{junction.id, junction}}, {});
-  const Validator dut(&parser, ValidatorOptions{true}, ValidatorConfig{1e-3});
-  const auto errors = dut.GetErrors();
+  const auto errors = ValidateLaneAdjacency(&parser, ValidatorConfig{1e-3});
   ASSERT_EQ(expected_errors.size(), errors.size());
   EXPECT_EQ(expected_errors, errors);
 }
 
-TEST_F(ValidatorTest, NoValidLeftLaneInTheSegment) {
+TEST_F(ValidateLaneAdjacencyTest, NoValidLeftLaneInTheSegment) {
   const std::vector<Validator::Error> expected_errors{
       {"Adjacent lane isn't part of the segment: Lane 2 has a left lane id (41856) that is not part of the segment "
        "segment.",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+       Validator::Error::Type::kLogicalLaneAdjacency, Validator::Error::Severity::kError},
       {"Wrong ordering of lanes: Lane 2 has a left lane id (41856) that is not the next lane in the segment "
        "segment.",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+       Validator::Error::Type::kLogicalLaneAdjacency, Validator::Error::Severity::kError},
       {"Wrong ordering of lanes: Lane 3 has a right lane id (2) that has a left lane id (41856) that is not the lane "
        "3.",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+       Validator::Error::Type::kLogicalLaneAdjacency, Validator::Error::Severity::kError},
   };
   Lane lane_2_no_valid_left_id{lane_2};
   lane_2_no_valid_left_id.left_lane_id = "41856";
   const MockParser parser{CreateMockParser({lane_0, lane_1, lane_2_no_valid_left_id, lane_3})};
-  const Validator dut(&parser, ValidatorOptions{true}, ValidatorConfig{1e-3});
-  const auto errors = dut.GetErrors();
+  const auto errors = ValidateLaneAdjacency(&parser, ValidatorConfig{1e-3});
   ASSERT_EQ(expected_errors.size(), errors.size());
   EXPECT_EQ(expected_errors, errors);
 }
 
-TEST_F(ValidatorTest, NoCorrespondenceForRightLane) {
+TEST_F(ValidateLaneAdjacencyTest, NoCorrespondenceForRightLane) {
   const std::vector<Validator::Error> expected_errors{
       {"Adjacent lane isn't part of the segment: Lane 0 has a left lane id (54656465) that is not part of the segment "
        "segment.",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+       Validator::Error::Type::kLogicalLaneAdjacency, Validator::Error::Severity::kError},
       {"Wrong ordering of lanes: Lane 0 has a left lane id (54656465) that is not the next lane in the segment "
        "segment.",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+       Validator::Error::Type::kLogicalLaneAdjacency, Validator::Error::Severity::kError},
       {"Wrong ordering of lanes: Lane 1 has a right lane id (0) that has a left lane id (54656465) that is not the "
        "lane 1.",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+       Validator::Error::Type::kLogicalLaneAdjacency, Validator::Error::Severity::kError},
       {"Wrong ordering of lanes: Lane 1 has no left lane id but it isn't the last lane in the segment segment.",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+       Validator::Error::Type::kLogicalLaneAdjacency, Validator::Error::Severity::kError},
       {"Wrong ordering of lanes: Lane 2 has a right lane id (1) that has no left lane id.",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+       Validator::Error::Type::kLogicalLaneAdjacency, Validator::Error::Severity::kError},
   };
   Lane lane_0_with_other_left_lane_id{lane_0};
   lane_0_with_other_left_lane_id.left_lane_id = "54656465";
@@ -154,27 +182,26 @@ TEST_F(ValidatorTest, NoCorrespondenceForRightLane) {
   lane_1_without_left_lane_id.left_lane_id = std::nullopt;
   const MockParser parser{
       CreateMockParser({lane_0_with_other_left_lane_id, lane_1_without_left_lane_id, lane_2, lane_3})};
-  const Validator dut(&parser, ValidatorOptions{true}, ValidatorConfig{1e-3});
-  const auto errors = dut.GetErrors();
+  const auto errors = ValidateLaneAdjacency(&parser, ValidatorConfig{1e-3});
   ASSERT_EQ(expected_errors.size(), errors.size());
   EXPECT_EQ(expected_errors, errors);
 }
 
-TEST_F(ValidatorTest, NoCorrespondenceForLeftLane) {
+TEST_F(ValidateLaneAdjacencyTest, NoCorrespondenceForLeftLane) {
   const std::vector<Validator::Error> expected_errors{
       {"Wrong ordering of lanes: Lane 1 has a left lane id (2) that has no right lane id.",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+       Validator::Error::Type::kLogicalLaneAdjacency, Validator::Error::Severity::kError},
       {"Wrong ordering of lanes: Lane 2 has no right lane id but it isn't the first lane in the segment segment.",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+       Validator::Error::Type::kLogicalLaneAdjacency, Validator::Error::Severity::kError},
       {"Wrong ordering of lanes: Lane 2 has a left lane id (3) that has a right lane id (54656465) that is not the "
        "lane 2.",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+       Validator::Error::Type::kLogicalLaneAdjacency, Validator::Error::Severity::kError},
       {"Adjacent lane isn't part of the segment: Lane 3 has a right lane id (54656465) that is not part of the segment "
        "segment.",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+       Validator::Error::Type::kLogicalLaneAdjacency, Validator::Error::Severity::kError},
       {"Wrong ordering of lanes: Lane 3 has a right lane id (54656465) that is not the previous lane in the segment "
        "segment.",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+       Validator::Error::Type::kLogicalLaneAdjacency, Validator::Error::Severity::kError},
   };
   Lane lane_2_without_right_lane_id{lane_2};
   lane_2_without_right_lane_id.right_lane_id = std::nullopt;
@@ -182,86 +209,80 @@ TEST_F(ValidatorTest, NoCorrespondenceForLeftLane) {
   lane_3_with_other_right_lane_id.right_lane_id = "54656465";
   const MockParser parser{
       CreateMockParser({lane_0, lane_1, lane_2_without_right_lane_id, lane_3_with_other_right_lane_id})};
-  const Validator dut(&parser, ValidatorOptions{true}, ValidatorConfig{1e-3});
-  const auto errors = dut.GetErrors();
+  const auto errors = ValidateLaneAdjacency(&parser, ValidatorConfig{1e-3});
   ASSERT_EQ(expected_errors.size(), errors.size());
   EXPECT_EQ(expected_errors, errors);
 }
 
-TEST_F(ValidatorTest, NoRightLaneIdForANonFirstLane) {
+TEST_F(ValidateLaneAdjacencyTest, NoRightLaneIdForANonFirstLane) {
   const std::vector<Validator::Error> expected_errors{
       {"Wrong ordering of lanes: Lane 0 has a left lane id (1) that has no right lane id.",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+       Validator::Error::Type::kLogicalLaneAdjacency, Validator::Error::Severity::kError},
       {"Wrong ordering of lanes: Lane 1 has no right lane id but it isn't the first lane in the segment segment.",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+       Validator::Error::Type::kLogicalLaneAdjacency, Validator::Error::Severity::kError},
   };
   Lane lane_1_without_right_lane_id{lane_1};
   lane_1_without_right_lane_id.right_lane_id = std::nullopt;
   const MockParser parser{CreateMockParser({lane_0, lane_1_without_right_lane_id, lane_2, lane_3})};
-  const Validator dut(&parser, ValidatorOptions{true}, ValidatorConfig{1e-3});
-  const auto errors = dut.GetErrors();
+  const auto errors = ValidateLaneAdjacency(&parser, ValidatorConfig{1e-3});
   ASSERT_EQ(expected_errors.size(), errors.size());
   EXPECT_EQ(expected_errors, errors);
 }
 
-TEST_F(ValidatorTest, NoLeftLaneIdForANonLastLane) {
+TEST_F(ValidateLaneAdjacencyTest, NoLeftLaneIdForANonLastLane) {
   const std::vector<Validator::Error> expected_errors{
       {"Wrong ordering of lanes: Lane 1 has no left lane id but it isn't the last lane in the segment segment.",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+       Validator::Error::Type::kLogicalLaneAdjacency, Validator::Error::Severity::kError},
       {"Wrong ordering of lanes: Lane 2 has a right lane id (1) that has no left lane id.",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+       Validator::Error::Type::kLogicalLaneAdjacency, Validator::Error::Severity::kError},
   };
   Lane lane_1_without_left_lane_id{lane_1};
   lane_1_without_left_lane_id.left_lane_id = std::nullopt;
   const MockParser parser{CreateMockParser({lane_0, lane_1_without_left_lane_id, lane_2, lane_3})};
-  const Validator dut(&parser, ValidatorOptions{true}, ValidatorConfig{1e-3});
-  const auto errors = dut.GetErrors();
+  const auto errors = ValidateLaneAdjacency(&parser, ValidatorConfig{1e-3});
   ASSERT_EQ(expected_errors.size(), errors.size());
   EXPECT_EQ(expected_errors, errors);
 }
 
-TEST_F(ValidatorTest, NoRightLanes) {
+TEST_F(ValidateLaneAdjacencyTest, NoRightLanes) {
   const std::vector<Validator::Error> expected_errors{
       {"Wrong ordering of lanes: Lane 3 has a right lane id (2) but is the first lane in the segment segment.",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+       Validator::Error::Type::kLogicalLaneAdjacency, Validator::Error::Severity::kError},
       {"Adjacent lane isn't part of the segment: Lane 3 has a right lane id (2) that is not part of the segment "
        "segment.",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+       Validator::Error::Type::kLogicalLaneAdjacency, Validator::Error::Severity::kError},
   };
   const MockParser parser{CreateMockParser({lane_3})};
-  const Validator dut(&parser, ValidatorOptions{true}, ValidatorConfig{1e-3});
-  const auto errors = dut.GetErrors();
+  const auto errors = ValidateLaneAdjacency(&parser, ValidatorConfig{1e-3});
   ASSERT_EQ(expected_errors.size(), errors.size());
   EXPECT_EQ(expected_errors, errors);
 }
 
-TEST_F(ValidatorTest, NoLeftLanes) {
+TEST_F(ValidateLaneAdjacencyTest, NoLeftLanes) {
   const std::vector<Validator::Error> expected_errors{
       {"Wrong ordering of lanes: Lane 0 has a left lane id (1) but is the last lane in the segment segment.",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+       Validator::Error::Type::kLogicalLaneAdjacency, Validator::Error::Severity::kError},
       {"Adjacent lane isn't part of the segment: Lane 0 has a left lane id (1) that is not part of the segment "
        "segment.",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+       Validator::Error::Type::kLogicalLaneAdjacency, Validator::Error::Severity::kError},
   };
   const MockParser parser{CreateMockParser({lane_0})};
-  const Validator dut(&parser, ValidatorOptions{true}, ValidatorConfig{1e-3});
-  const auto errors = dut.GetErrors();
+  const auto errors = ValidateLaneAdjacency(&parser, ValidatorConfig{1e-3});
   ASSERT_EQ(expected_errors.size(), errors.size());
   EXPECT_EQ(expected_errors, errors);
 }
 
-TEST_F(ValidatorTest, NoGeometricallyAdjacentLanes) {
+TEST_F(ValidateLaneAdjacencyTest, NoGeometricallyAdjacentLanes) {
   Lane lane_0_no_geometrically_adj{lane_0};
   lane_0_no_geometrically_adj.left = LineString3d{{1., 7., 1.}, {10., 7., 1.}};
   const std::vector<Validator::Error> expected_errors{
-      {"Lane 0 and lane 1 are not adjacent under the tolerance 0.001000. (distance: 6.000000)",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
-      {"Lane 1 and lane 0 are not adjacent under the tolerance 0.001000. (distance: 6.000000)",
-       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+      {"Lane 0 and lane 1 are not adjacent under the tolerance 0.001000.",
+       Validator::Error::Type::kGeometricalLaneAdjacency, Validator::Error::Severity::kError},
+      {"Lane 1 and lane 0 are not adjacent under the tolerance 0.001000.",
+       Validator::Error::Type::kGeometricalLaneAdjacency, Validator::Error::Severity::kError},
   };
   const MockParser parser{CreateMockParser({lane_0_no_geometrically_adj, lane_1, lane_2, lane_3})};
-  const Validator dut(&parser, ValidatorOptions{true}, ValidatorConfig{1e-3});
-  const auto errors = dut.GetErrors();
+  const auto errors = ValidateLaneAdjacency(&parser, ValidatorConfig{1e-3});
   ASSERT_EQ(expected_errors.size(), errors.size());
   EXPECT_EQ(expected_errors, errors);
 }

--- a/test/parser/validator_test.cc
+++ b/test/parser/validator_test.cc
@@ -1,0 +1,272 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "maliput_sparse/parser/validator.h"
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "maliput_sparse/parser/parser.h"
+
+namespace maliput_sparse {
+namespace parser {
+namespace test {
+namespace {
+
+using maliput_sparse::geometry::LineString3d;
+
+class MockParser : public Parser {
+ public:
+  MockParser(const std::unordered_map<Junction::Id, Junction>& junctions = {},
+             const std::vector<Connection>& connections = {})
+      : junctions_(junctions), connections_(connections) {}
+
+ private:
+  const std::unordered_map<Junction::Id, Junction>& DoGetJunctions() const override { return junctions_; }
+  const std::vector<Connection>& DoGetConnections() const override { return connections_; }
+  const std::unordered_map<Junction::Id, Junction> junctions_;
+  const std::vector<Connection> connections_;
+};
+
+Lane CreateLane(const Lane::Id& id, const LineString3d& left, const LineString3d& right,
+                const std::optional<Lane::Id>& left_lane_id, const std::optional<Lane::Id>& right_lane_id,
+                const std::unordered_map<Lane::Id, LaneEnd>& successors,
+                const std::unordered_map<Lane::Id, LaneEnd>& predecessors) {
+  return Lane{id, left, right, left_lane_id, right_lane_id, successors, predecessors};
+}
+
+class ValidatorTest : public ::testing::Test {
+ public:
+  static MockParser CreateMockParser(const std::vector<Lane>& lanes) {
+    const Junction junction{"junction", {{"segment", Segment{"segment", lanes}}}};
+    return MockParser({{junction.id, junction}}, {});
+  }
+
+  const Lane lane_0 = CreateLane("0", LineString3d{{1., 1., 1.}, {10., 1., 1.}},
+                                 LineString3d{{1., -1., 1.}, {10., -1., 1.}}, {"1"}, std::nullopt, {}, {});
+  const Lane lane_1 = CreateLane("1", LineString3d{{1., 3., 1.}, {10., 3., 1.}},
+                                 LineString3d{{1., 1., 1.}, {10., 1., 1.}}, {"2"}, {"0"}, {}, {});
+  const Lane lane_2 = CreateLane("2", LineString3d{{1., 5., 1.}, {10., 5., 1.}},
+                                 LineString3d{{1., 3., 1.}, {10., 3., 1.}}, {"3"}, {"1"}, {}, {});
+  const Lane lane_3 = CreateLane("3", LineString3d{{1., 7., 1.}, {10., 7., 1.}},
+                                 LineString3d{{1., 5., 1.}, {10., 5., 1.}}, std::nullopt, {"2"}, {}, {});
+};
+
+TEST_F(ValidatorTest, NoErrors) {
+  const Segment segment{"segment", {lane_0, lane_1, lane_2, lane_3}};
+  const Junction junction{"junction", {{segment.id, segment}}};
+  const MockParser parser({{junction.id, junction}}, {});
+  const Validator dut(&parser, ValidatorOptions{true}, ValidatorConfig{1e-3});
+  const auto errors = dut.GetErrors();
+  EXPECT_EQ(0., errors.size());
+}
+
+TEST_F(ValidatorTest, NoValidRightLaneInTheSegment) {
+  const std::vector<Validator::Error> expected_errors{
+      {"Wrong ordering of lanes: Lane 1 has a left lane id (2) that has a right lane id (41856) that is not the lane "
+       "1.",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+      {"Adjacent lane isn't part of the segment: Lane 2 has a right lane id (41856) that is not part of the segment "
+       "segment.",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+      {"Wrong ordering of lanes: Lane 2 has a right lane id (41856) that is not the previous lane in the segment "
+       "segment.",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+  };
+  Lane lane_2_no_valid_right_id{lane_2};
+  lane_2_no_valid_right_id.right_lane_id = "41856";
+  const Segment segment{"segment", {lane_0, lane_1, lane_2_no_valid_right_id, lane_3}};
+  const Junction junction{"junction", {{segment.id, segment}}};
+  const MockParser parser({{junction.id, junction}}, {});
+  const Validator dut(&parser, ValidatorOptions{true}, ValidatorConfig{1e-3});
+  const auto errors = dut.GetErrors();
+  ASSERT_EQ(expected_errors.size(), errors.size());
+  EXPECT_EQ(expected_errors, errors);
+}
+
+TEST_F(ValidatorTest, NoValidLeftLaneInTheSegment) {
+  const std::vector<Validator::Error> expected_errors{
+      {"Adjacent lane isn't part of the segment: Lane 2 has a left lane id (41856) that is not part of the segment "
+       "segment.",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+      {"Wrong ordering of lanes: Lane 2 has a left lane id (41856) that is not the next lane in the segment "
+       "segment.",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+      {"Wrong ordering of lanes: Lane 3 has a right lane id (2) that has a left lane id (41856) that is not the lane "
+       "3.",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+  };
+  Lane lane_2_no_valid_left_id{lane_2};
+  lane_2_no_valid_left_id.left_lane_id = "41856";
+  const MockParser parser{CreateMockParser({lane_0, lane_1, lane_2_no_valid_left_id, lane_3})};
+  const Validator dut(&parser, ValidatorOptions{true}, ValidatorConfig{1e-3});
+  const auto errors = dut.GetErrors();
+  ASSERT_EQ(expected_errors.size(), errors.size());
+  EXPECT_EQ(expected_errors, errors);
+}
+
+TEST_F(ValidatorTest, NoCorrespondenceForRightLane) {
+  const std::vector<Validator::Error> expected_errors{
+      {"Adjacent lane isn't part of the segment: Lane 0 has a left lane id (54656465) that is not part of the segment "
+       "segment.",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+      {"Wrong ordering of lanes: Lane 0 has a left lane id (54656465) that is not the next lane in the segment "
+       "segment.",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+      {"Wrong ordering of lanes: Lane 1 has a right lane id (0) that has a left lane id (54656465) that is not the "
+       "lane 1.",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+      {"Wrong ordering of lanes: Lane 1 has no left lane id but it isn't the last lane in the segment segment.",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+      {"Wrong ordering of lanes: Lane 2 has a right lane id (1) that has no left lane id.",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+  };
+  Lane lane_0_with_other_left_lane_id{lane_0};
+  lane_0_with_other_left_lane_id.left_lane_id = "54656465";
+  Lane lane_1_without_left_lane_id{lane_1};
+  lane_1_without_left_lane_id.left_lane_id = std::nullopt;
+  const MockParser parser{
+      CreateMockParser({lane_0_with_other_left_lane_id, lane_1_without_left_lane_id, lane_2, lane_3})};
+  const Validator dut(&parser, ValidatorOptions{true}, ValidatorConfig{1e-3});
+  const auto errors = dut.GetErrors();
+  ASSERT_EQ(expected_errors.size(), errors.size());
+  EXPECT_EQ(expected_errors, errors);
+}
+
+TEST_F(ValidatorTest, NoCorrespondenceForLeftLane) {
+  const std::vector<Validator::Error> expected_errors{
+      {"Wrong ordering of lanes: Lane 1 has a left lane id (2) that has no right lane id.",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+      {"Wrong ordering of lanes: Lane 2 has no right lane id but it isn't the first lane in the segment segment.",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+      {"Wrong ordering of lanes: Lane 2 has a left lane id (3) that has a right lane id (54656465) that is not the "
+       "lane 2.",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+      {"Adjacent lane isn't part of the segment: Lane 3 has a right lane id (54656465) that is not part of the segment "
+       "segment.",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+      {"Wrong ordering of lanes: Lane 3 has a right lane id (54656465) that is not the previous lane in the segment "
+       "segment.",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+  };
+  Lane lane_2_without_right_lane_id{lane_2};
+  lane_2_without_right_lane_id.right_lane_id = std::nullopt;
+  Lane lane_3_with_other_right_lane_id{lane_3};
+  lane_3_with_other_right_lane_id.right_lane_id = "54656465";
+  const MockParser parser{
+      CreateMockParser({lane_0, lane_1, lane_2_without_right_lane_id, lane_3_with_other_right_lane_id})};
+  const Validator dut(&parser, ValidatorOptions{true}, ValidatorConfig{1e-3});
+  const auto errors = dut.GetErrors();
+  ASSERT_EQ(expected_errors.size(), errors.size());
+  EXPECT_EQ(expected_errors, errors);
+}
+
+TEST_F(ValidatorTest, NoRightLaneIdForANonFirstLane) {
+  const std::vector<Validator::Error> expected_errors{
+      {"Wrong ordering of lanes: Lane 0 has a left lane id (1) that has no right lane id.",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+      {"Wrong ordering of lanes: Lane 1 has no right lane id but it isn't the first lane in the segment segment.",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+  };
+  Lane lane_1_without_right_lane_id{lane_1};
+  lane_1_without_right_lane_id.right_lane_id = std::nullopt;
+  const MockParser parser{CreateMockParser({lane_0, lane_1_without_right_lane_id, lane_2, lane_3})};
+  const Validator dut(&parser, ValidatorOptions{true}, ValidatorConfig{1e-3});
+  const auto errors = dut.GetErrors();
+  ASSERT_EQ(expected_errors.size(), errors.size());
+  EXPECT_EQ(expected_errors, errors);
+}
+
+TEST_F(ValidatorTest, NoLeftLaneIdForANonLastLane) {
+  const std::vector<Validator::Error> expected_errors{
+      {"Wrong ordering of lanes: Lane 1 has no left lane id but it isn't the last lane in the segment segment.",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+      {"Wrong ordering of lanes: Lane 2 has a right lane id (1) that has no left lane id.",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+  };
+  Lane lane_1_without_left_lane_id{lane_1};
+  lane_1_without_left_lane_id.left_lane_id = std::nullopt;
+  const MockParser parser{CreateMockParser({lane_0, lane_1_without_left_lane_id, lane_2, lane_3})};
+  const Validator dut(&parser, ValidatorOptions{true}, ValidatorConfig{1e-3});
+  const auto errors = dut.GetErrors();
+  ASSERT_EQ(expected_errors.size(), errors.size());
+  EXPECT_EQ(expected_errors, errors);
+}
+
+TEST_F(ValidatorTest, NoRightLanes) {
+  const std::vector<Validator::Error> expected_errors{
+      {"Wrong ordering of lanes: Lane 3 has a right lane id (2) but is the first lane in the segment segment.",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+      {"Adjacent lane isn't part of the segment: Lane 3 has a right lane id (2) that is not part of the segment "
+       "segment.",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+  };
+  const MockParser parser{CreateMockParser({lane_3})};
+  const Validator dut(&parser, ValidatorOptions{true}, ValidatorConfig{1e-3});
+  const auto errors = dut.GetErrors();
+  ASSERT_EQ(expected_errors.size(), errors.size());
+  EXPECT_EQ(expected_errors, errors);
+}
+
+TEST_F(ValidatorTest, NoLeftLanes) {
+  const std::vector<Validator::Error> expected_errors{
+      {"Wrong ordering of lanes: Lane 0 has a left lane id (1) but is the last lane in the segment segment.",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+      {"Adjacent lane isn't part of the segment: Lane 0 has a left lane id (1) that is not part of the segment "
+       "segment.",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+  };
+  const MockParser parser{CreateMockParser({lane_0})};
+  const Validator dut(&parser, ValidatorOptions{true}, ValidatorConfig{1e-3});
+  const auto errors = dut.GetErrors();
+  ASSERT_EQ(expected_errors.size(), errors.size());
+  EXPECT_EQ(expected_errors, errors);
+}
+
+TEST_F(ValidatorTest, NoGeometricallyAdjacentLanes) {
+  Lane lane_0_no_geometrically_adj{lane_0};
+  lane_0_no_geometrically_adj.left = LineString3d{{1., 7., 1.}, {10., 7., 1.}};
+  const std::vector<Validator::Error> expected_errors{
+      {"Lane 0 and lane 1 are not adjacent under the tolerance 0.001000. (distance: 6.000000)",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+      {"Lane 1 and lane 0 are not adjacent under the tolerance 0.001000. (distance: 6.000000)",
+       Validator::Error::Type::kLaneAdjacency, Validator::Error::Severity::kError},
+  };
+  const MockParser parser{CreateMockParser({lane_0_no_geometrically_adj, lane_1, lane_2, lane_3})};
+  const Validator dut(&parser, ValidatorOptions{true}, ValidatorConfig{1e-3});
+  const auto errors = dut.GetErrors();
+  ASSERT_EQ(expected_errors.size(), errors.size());
+  EXPECT_EQ(expected_errors, errors);
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace parser
+}  // namespace maliput_sparse


### PR DESCRIPTION
# 🎉 New feature

Related to #30 

## Summary

- Creates a `parser::Validator` for verifying the parsed information before calling the builder.
- Adds a validation for the adjacency of the lanes in a segment.
- Adds a method for analyzing the distance between LineStrings3d.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

