### PR TITLE
Uses the closest point to calculate the equivalent p in a boundary.

### DIFF
--- a/include/maliput_sparse/geometry/utility/geometry.h
+++ b/include/maliput_sparse/geometry/utility/geometry.h
@@ -38,22 +38,32 @@ namespace geometry {
 namespace utility {
 
 /// Holds the result of #GetBoundPointsAtP method.
+/// @tparam T The coordinate type.
+template <typename T>
 struct BoundPointsResult {
-  LineString3d::const_iterator first;
-  LineString3d::const_iterator second;
+  typename LineString<T>::const_iterator first;
+  typename LineString<T>::const_iterator second;
   // Length up to first.
   double length;
 };
 
+using BoundPointsResult3d = BoundPointsResult<maliput::math::Vector3>;
+using BoundPointsResult2d = BoundPointsResult<maliput::math::Vector2>;
+
 /// Holds the result of #GetClosestPoint method.
+/// @tparam T The coordinate type.
+template <typename T>
 struct ClosestPointResult {
   /// P coordinate in the line string matching the closest point.
   double p;
   /// Closest point.
-  maliput::math::Vector3 point;
+  T point;
   /// Distance between the closest point and the given point.
   double distance;
 };
+
+using ClosestPointResult3d = ClosestPointResult<maliput::math::Vector3>;
+using ClosestPointResult2d = ClosestPointResult<maliput::math::Vector2>;
 
 /// Computes a 3-dimensional centerline out of the @p left and @p right line string.
 ///
@@ -66,10 +76,12 @@ LineString3d ComputeCenterline3d(const LineString3d& left, const LineString3d& r
 
 /// Returns the piecewise linearly interpolated point at the given distance and the distance from the beginning to the
 /// first point.
+/// @tparam T The coordinate type of the @p line_string .
 /// @param line_string the line_string to iterate.
 /// @param p distance along line_string.
 /// @return The interpolated point (a new point if not perfectly matching).
-maliput::math::Vector3 InterpolatedPointAtP(const LineString3d& line_string, double p);
+template <typename T = maliput::math::Vector3>
+T InterpolatedPointAtP(const LineString<T>& line_string, double p);
 
 /// Returns the slope of a @p line_string for a given @p p .
 /// The slope is calculated as the variation in `z` divided by the variation in the `xy` plane.
@@ -84,7 +96,8 @@ double GetSlopeAtP(const LineString3d& line_string, double p);
 /// @param line_string LineString.
 /// @param p P parameter.
 /// @throws maliput::common::assertion_error When `p ∉ [0., line_string.length()]`.
-BoundPointsResult GetBoundPointsAtP(const LineString3d& line_string, double p);
+template <typename T = maliput::math::Vector3>
+BoundPointsResult<T> GetBoundPointsAtP(const LineString<T>& line_string, double p);
 
 /// Returns the heading of a @p line_string for a given @p p .
 /// @param line_string LineString to be computed the heading from.
@@ -107,18 +120,28 @@ maliput::math::Vector3 GetTangentAtP(const LineString3d& line_string, double p);
 
 /// Gets the closest point in the @p segment to the given @p xyz point.
 /// @param segment Segment to be computed the closest point from.
-/// @param xyz Point to be computed the closest point to.
+/// @param coordinate Point to be computed the closest point to.
 /// @return A ClosestPointResult struct containing the closest point, the distance between the closest point and @p xyz
 /// and the p coordinate in the segment matching the closest point.
-ClosestPointResult GetClosestPoint(const std::pair<maliput::math::Vector3, maliput::math::Vector3>& segment,
-                                   const maliput::math::Vector3& xyz);
+template <typename T = maliput::math::Vector3>
+ClosestPointResult<T> GetClosestPointToSegment(const std::pair<T, T>& segment, const T& coordinate);
 
 /// Gets the closest point in the @p line_string to the given @p xyz point.
 /// @param line_string LineString3d to be computed the closest point from.
 /// @param xyz Point to be computed the closest point to.
 /// @return A ClosestPointResult struct containing the closest point, the distance between the closest point and @p xyz
 /// and the p coordinate in the LineString3d matching the closest point.
-ClosestPointResult GetClosestPoint(const LineString3d& line_string, const maliput::math::Vector3& xyz);
+ClosestPointResult3d GetClosestPoint(const LineString3d& line_string, const maliput::math::Vector3& xyz);
+
+/// Gets the closest point in the @p line_string to the given @p xyz point.
+/// @details This method is similar to #ref GetClosestPoint, but it first projects the @p line_string and the @p xyz on
+/// the xy plane for finding the closest point. Once the closest point in the plane is found, the z coordinate is
+/// recovered from the @p line_string and the rest of the ClosestPointResult3d struct is filled.
+/// @param line_string LineString3d to be computed the closest point from.
+/// @param xyz Point to be computed the closest point to.
+/// @return A ClosestPointResult struct containing the closest point, the distance between the closest point and @p xyz
+ClosestPointResult3d GetClosestPointUsing2dProjection(const LineString3d& line_string,
+                                                      const maliput::math::Vector3& xyz);
 
 /// Computes the distance between two LineString3d.
 /// The distance is calculated as the sum of distances between corresponding points between both line strings divided by

--- a/include/maliput_sparse/geometry/utility/geometry.h
+++ b/include/maliput_sparse/geometry/utility/geometry.h
@@ -38,11 +38,11 @@ namespace geometry {
 namespace utility {
 
 /// Holds the result of #GetBoundPointsAtP method.
-/// @tparam T The coordinate type.
-template <typename T>
+/// @tparam CoordinateT The coordinate type.
+template <typename CoordinateT>
 struct BoundPointsResult {
-  typename LineString<T>::const_iterator first;
-  typename LineString<T>::const_iterator second;
+  typename LineString<CoordinateT>::const_iterator first;
+  typename LineString<CoordinateT>::const_iterator second;
   // Length up to first.
   double length;
 };
@@ -51,13 +51,13 @@ using BoundPointsResult3d = BoundPointsResult<maliput::math::Vector3>;
 using BoundPointsResult2d = BoundPointsResult<maliput::math::Vector2>;
 
 /// Holds the result of #GetClosestPoint method.
-/// @tparam T The coordinate type.
-template <typename T>
+/// @tparam CoordinateT The coordinate type.
+template <typename CoordinateT>
 struct ClosestPointResult {
   /// P coordinate in the line string matching the closest point.
   double p;
   /// Closest point.
-  T point;
+  CoordinateT point;
   /// Distance between the closest point and the given point.
   double distance;
 };
@@ -76,12 +76,12 @@ LineString3d ComputeCenterline3d(const LineString3d& left, const LineString3d& r
 
 /// Returns the piecewise linearly interpolated point at the given distance and the distance from the beginning to the
 /// first point.
-/// @tparam T The coordinate type of the @p line_string .
+/// @tparam CoordinateT The coordinate type of the @p line_string .
 /// @param line_string the line_string to iterate.
 /// @param p distance along line_string.
 /// @return The interpolated point (a new point if not perfectly matching).
-template <typename T = maliput::math::Vector3>
-T InterpolatedPointAtP(const LineString<T>& line_string, double p);
+template <typename CoordinateT = maliput::math::Vector3>
+CoordinateT InterpolatedPointAtP(const LineString<CoordinateT>& line_string, double p);
 
 /// Returns the slope of a @p line_string for a given @p p .
 /// The slope is calculated as the variation in `z` divided by the variation in the `xy` plane.
@@ -93,11 +93,12 @@ T InterpolatedPointAtP(const LineString<T>& line_string, double p);
 double GetSlopeAtP(const LineString3d& line_string, double p);
 
 /// Obtains the points that confines @p p in the @p line_string .
+/// @tparam CoordinateT The coordinate type of the @p line_string .
 /// @param line_string LineString.
 /// @param p P parameter.
 /// @throws maliput::common::assertion_error When `p ∉ [0., line_string.length()]`.
-template <typename T = maliput::math::Vector3>
-BoundPointsResult<T> GetBoundPointsAtP(const LineString<T>& line_string, double p);
+template <typename CoordinateT = maliput::math::Vector3>
+BoundPointsResult<CoordinateT> GetBoundPointsAtP(const LineString<CoordinateT>& line_string, double p);
 
 /// Returns the heading of a @p line_string for a given @p p .
 /// @param line_string LineString to be computed the heading from.
@@ -119,12 +120,14 @@ maliput::math::Vector2 Get2DTangentAtP(const LineString3d& line_string, double p
 maliput::math::Vector3 GetTangentAtP(const LineString3d& line_string, double p);
 
 /// Gets the closest point in the @p segment to the given @p xyz point.
+/// @tparam CoordinateT The coordinate type of the @p segment .
 /// @param segment Segment to be computed the closest point from.
 /// @param coordinate Point to be computed the closest point to.
 /// @return A ClosestPointResult struct containing the closest point, the distance between the closest point and @p xyz
 /// and the p coordinate in the segment matching the closest point.
-template <typename T = maliput::math::Vector3>
-ClosestPointResult<T> GetClosestPointToSegment(const std::pair<T, T>& segment, const T& coordinate);
+template <typename CoordinateT = maliput::math::Vector3>
+ClosestPointResult<CoordinateT> GetClosestPointToSegment(const std::pair<CoordinateT, CoordinateT>& segment,
+                                                         const CoordinateT& coordinate);
 
 /// Gets the closest point in the @p line_string to the given @p xyz point.
 /// @param line_string LineString3d to be computed the closest point from.

--- a/src/geometry/lane_geometry.cc
+++ b/src/geometry/lane_geometry.cc
@@ -146,11 +146,11 @@ maliput::api::RBounds LaneGeometry::RBounds(double p) const {
 double LaneGeometry::FromCenterPToLateralP(const LineStringType& line_string_type, double p) const {
   p = range_validator_(p);
   MALIPUT_THROW_UNLESS(line_string_type != LineStringType::kCenterLine);
-  // Given p in centerline, let's compute p_at_a_border as: p_at_a_border = p / length * length_at_a_border.
-  // See https://github.com/maliput/maliput_sparse/issues/15 for more details.
-  const double lateral_length = line_string_type == LineStringType::kLeftBoundary ? left_.length() : right_.length();
-  const double p_equivalent = p * lateral_length / centerline_.length();
-  return std::clamp(p_equivalent, 0., lateral_length);
+  const maliput::math::Vector3 point_at_p = utility::InterpolatedPointAtP(centerline_, p);
+  // The lateral p is the one that matches closest point in the lateral to the centerline at p.
+  const utility::ClosestPointResult closest_to_point =
+      utility::GetClosestPoint(line_string_type == LineStringType::kLeftBoundary ? left_ : right_, point_at_p);
+  return closest_to_point.p;
 }
 
 maliput::math::Vector3 LaneGeometry::ToLateralPos(const LineStringType& line_string_type, double p) const {

--- a/src/geometry/lane_geometry.cc
+++ b/src/geometry/lane_geometry.cc
@@ -148,8 +148,8 @@ double LaneGeometry::FromCenterPToLateralP(const LineStringType& line_string_typ
   MALIPUT_THROW_UNLESS(line_string_type != LineStringType::kCenterLine);
   const maliput::math::Vector3 point_at_p = utility::InterpolatedPointAtP(centerline_, p);
   // The lateral p is the one that matches closest point in the lateral to the centerline at p.
-  const utility::ClosestPointResult closest_to_point =
-      utility::GetClosestPoint(line_string_type == LineStringType::kLeftBoundary ? left_ : right_, point_at_p);
+  const utility::ClosestPointResult closest_to_point = utility::GetClosestPointUsing2dProjection(
+      line_string_type == LineStringType::kLeftBoundary ? left_ : right_, point_at_p);
   return closest_to_point.p;
 }
 

--- a/src/geometry/utility/geometry.cc
+++ b/src/geometry/utility/geometry.cc
@@ -312,6 +312,8 @@ double GetSlopeAtP(const LineString3d& line_string, double p) {
 
 template <typename T>
 BoundPointsResult<T> GetBoundPointsAtP(const LineString<T>& line_string, double p) {
+  MALIPUT_THROW_UNLESS(p >= 0);
+  MALIPUT_THROW_UNLESS(p <= line_string.length());
   BoundPointsResult<T> result;
   double current_cumulative_length = 0.0;
   for (auto first = line_string.begin(), second = std::next(line_string.begin()); second != line_string.end();

--- a/src/geometry/utility/geometry.cc
+++ b/src/geometry/utility/geometry.cc
@@ -284,8 +284,8 @@ LineString3d ComputeCenterline3d(const LineString3d& left, const LineString3d& r
   return LineString3d{centerline};
 }
 
-template <typename T>
-T InterpolatedPointAtP(const LineString<T>& line_string, double p) {
+template <typename CoordinateT>
+CoordinateT InterpolatedPointAtP(const LineString<CoordinateT>& line_string, double p) {
   // Implementation inspired on:
   // https://github.com/fzi-forschungszentrum-informatik/Lanelet2/blob/master/lanelet2_core/include/lanelet2_core/geometry/impl/LineString.h#L618
   static constexpr double kEpsilon{1e-12};
@@ -310,11 +310,11 @@ double GetSlopeAtP(const LineString3d& line_string, double p) {
   return delta_z / dist;
 }
 
-template <typename T>
-BoundPointsResult<T> GetBoundPointsAtP(const LineString<T>& line_string, double p) {
+template <typename CoordinateT>
+BoundPointsResult<CoordinateT> GetBoundPointsAtP(const LineString<CoordinateT>& line_string, double p) {
   MALIPUT_THROW_UNLESS(p >= 0);
   MALIPUT_THROW_UNLESS(p <= line_string.length());
-  BoundPointsResult<T> result;
+  BoundPointsResult<CoordinateT> result;
   double current_cumulative_length = 0.0;
   for (auto first = line_string.begin(), second = std::next(line_string.begin()); second != line_string.end();
        ++first, ++second) {
@@ -349,14 +349,15 @@ Vector3 GetTangentAtP(const LineString3d& line_string, double p) {
   return (d_xyz / (line_string.length())).normalized();
 }
 
-template <typename T>
-ClosestPointResult<T> GetClosestPointToSegment(const std::pair<T, T>& segment, const T& coordinate) {
-  const T d_segment{segment.second - segment.first};
-  const T d_coordinate_to_first{coordinate - segment.first};
+template <typename CoordinateT>
+ClosestPointResult<CoordinateT> GetClosestPointToSegment(const std::pair<CoordinateT, CoordinateT>& segment,
+                                                         const CoordinateT& coordinate) {
+  const CoordinateT d_segment{segment.second - segment.first};
+  const CoordinateT d_coordinate_to_first{coordinate - segment.first};
 
   const double unsaturated_p = d_coordinate_to_first.dot(d_segment.normalized());
   const double p = std::clamp(unsaturated_p, 0., d_segment.norm());
-  const T point = InterpolatedPointAtP(LineString<T>{segment.first, segment.second}, p);
+  const CoordinateT point = InterpolatedPointAtP(LineString<CoordinateT>{segment.first, segment.second}, p);
   const double distance = (coordinate - point).norm();
   return {p, point, distance};
 }

--- a/src/geometry/utility/geometry.cc
+++ b/src/geometry/utility/geometry.cc
@@ -284,7 +284,8 @@ LineString3d ComputeCenterline3d(const LineString3d& left, const LineString3d& r
   return LineString3d{centerline};
 }
 
-Vector3 InterpolatedPointAtP(const LineString3d& line_string, double p) {
+template <typename T>
+T InterpolatedPointAtP(const LineString<T>& line_string, double p) {
   // Implementation inspired on:
   // https://github.com/fzi-forschungszentrum-informatik/Lanelet2/blob/master/lanelet2_core/include/lanelet2_core/geometry/impl/LineString.h#L618
   static constexpr double kEpsilon{1e-12};
@@ -309,11 +310,9 @@ double GetSlopeAtP(const LineString3d& line_string, double p) {
   return delta_z / dist;
 }
 
-BoundPointsResult GetBoundPointsAtP(const LineString3d& line_string, double p) {
-  MALIPUT_THROW_UNLESS(p >= 0);
-  MALIPUT_THROW_UNLESS(p <= line_string.length());
-
-  BoundPointsResult result;
+template <typename T>
+BoundPointsResult<T> GetBoundPointsAtP(const LineString<T>& line_string, double p) {
+  BoundPointsResult<T> result;
   double current_cumulative_length = 0.0;
   for (auto first = line_string.begin(), second = std::next(line_string.begin()); second != line_string.end();
        ++first, ++second) {
@@ -348,27 +347,56 @@ Vector3 GetTangentAtP(const LineString3d& line_string, double p) {
   return (d_xyz / (line_string.length())).normalized();
 }
 
-ClosestPointResult GetClosestPoint(const Segment3d& segment, const maliput::math::Vector3& xyz) {
-  const maliput::math::Vector3 d_segment{segment.second - segment.first};
-  const maliput::math::Vector3 d_xyz_to_first{xyz - segment.first};
+template <typename T>
+ClosestPointResult<T> GetClosestPointToSegment(const std::pair<T, T>& segment, const T& coordinate) {
+  const T d_segment{segment.second - segment.first};
+  const T d_coordinate_to_first{coordinate - segment.first};
 
-  const double unsaturated_p = d_xyz_to_first.dot(d_segment.normalized());
+  const double unsaturated_p = d_coordinate_to_first.dot(d_segment.normalized());
   const double p = std::clamp(unsaturated_p, 0., d_segment.norm());
-  const maliput::math::Vector3 point = InterpolatedPointAtP(LineString3d{segment.first, segment.second}, p);
-  const double distance = (xyz - point).norm();
+  const T point = InterpolatedPointAtP(LineString<T>{segment.first, segment.second}, p);
+  const double distance = (coordinate - point).norm();
   return {p, point, distance};
 }
 
-ClosestPointResult GetClosestPoint(const LineString3d& line_string, const maliput::math::Vector3& xyz) {
-  ClosestPointResult result;
+ClosestPointResult3d GetClosestPoint(const LineString3d& line_string, const maliput::math::Vector3& xyz) {
+  ClosestPointResult3d result;
   result.distance = std::numeric_limits<double>::max();
   double length{};
   for (auto first = line_string.begin(), second = std::next(line_string.begin()); second != line_string.end();
        ++first, ++second) {
-    const auto closest_point_res = GetClosestPoint(Segment3d{*first, *second}, xyz);
+    const auto closest_point_res = GetClosestPointToSegment(Segment3d{*first, *second}, xyz);
     if (closest_point_res.distance < result.distance) {
       result = closest_point_res;
       result.p += length;
+    }
+    length += (*second - *first).norm();  //> Adds segment length
+  }
+  return result;
+}
+
+ClosestPointResult3d GetClosestPointUsing2dProjection(const LineString3d& line_string,
+                                                      const maliput::math::Vector3& xyz) {
+  ClosestPointResult3d result;
+  result.distance = std::numeric_limits<double>::max();
+  double length{};
+  for (auto first = line_string.begin(), second = std::next(line_string.begin()); second != line_string.end();
+       ++first, ++second) {
+    const maliput::math::Vector2 first_2d = To2D(*first);
+    const maliput::math::Vector2 second_2d = To2D(*second);
+    const maliput::math::Vector2 xy = To2D(xyz);
+    const Segment2d segment_2d{first_2d, second_2d};
+    const auto closest_point_res = GetClosestPointToSegment(segment_2d, xy);
+    if (closest_point_res.distance < result.distance) {
+      const LineString3d segment_linestring_3d{*first, *second};
+      const double scale_p = segment_linestring_3d.length() / (segment_2d.first - segment_2d.second).norm();
+      const maliput::math::Vector3 closest_point_3d{
+          closest_point_res.point.x(), closest_point_res.point.y(),
+          InterpolatedPointAtP(segment_linestring_3d, closest_point_res.p * scale_p).z()};
+
+      result.distance = (xyz - closest_point_3d).norm();
+      result.point = closest_point_3d;
+      result.p = length + closest_point_res.p * scale_p;
     }
     length += (*second - *first).norm();  //> Adds segment length
   }
@@ -385,6 +413,23 @@ double ComputeDistance(const LineString3d& lhs, const LineString3d& rhs) {
       });
   return sum_distances / static_cast<double>(base_ls.size());
 }
+
+// Explicit instantiations
+
+template BoundPointsResult3d GetBoundPointsAtP(const LineString3d&, double);
+template BoundPointsResult2d GetBoundPointsAtP(const LineString2d&, double);
+
+template maliput::math::Vector3 InterpolatedPointAtP(const LineString3d&, double);
+template maliput::math::Vector2 InterpolatedPointAtP(const LineString2d&, double);
+
+template ClosestPointResult3d GetClosestPointToSegment(const Segment3d&, const maliput::math::Vector3&);
+template ClosestPointResult2d GetClosestPointToSegment(const Segment2d&, const maliput::math::Vector2&);
+
+template class BoundPointsResult<maliput::math::Vector3>;
+template class BoundPointsResult<maliput::math::Vector2>;
+
+template class ClosestPointResult<maliput::math::Vector3>;
+template class ClosestPointResult<maliput::math::Vector2>;
 
 }  // namespace utility
 }  // namespace geometry

--- a/test/base/lane_test.cc
+++ b/test/base/lane_test.cc
@@ -343,10 +343,7 @@ std::vector<ToLaneSegmentPositionTestCase> ToLaneSegmentPositionTestCases() {
                   },
                   // Outside boundary of the lane.
                   {
-                      // Because of the scaling of the boundaries' linestring the r value is slightly different.
-                      {50., 2.042240, 0.} /* lane_position */,
-                      {50., 2.042240, 100.} /* nearest_position */,
-                      7.9577602284126803, /* distance */
+                      {50., 2., 0.} /* lane_position */, {50., 2., 100.} /* nearest_position */, 8., /* distance */
                   },
               } /* expected_lane_position_result */,
               {
@@ -360,10 +357,7 @@ std::vector<ToLaneSegmentPositionTestCase> ToLaneSegmentPositionTestCases() {
                   },
                   // Outside boundary of the lane.
                   {
-                      // Because of the scaling of the boundaries' linestring the r value is slightly different.
-                      {50., 2.042240, 0.} /* lane_position */,
-                      {50., 2.042240, 100.} /* nearest_position */,
-                      7.9577602284126803, /* distance */
+                      {50., 2., 0.} /* lane_position */, {50., 2., 100.} /* nearest_position */, 8., /* distance */
                   },
               } /* expected_segment_lane_position_result */
           }};

--- a/test/geometry/lane_geometry_test.cc
+++ b/test/geometry/lane_geometry_test.cc
@@ -72,7 +72,7 @@ struct OrientationTestCase {
 std::vector<OrientationTestCase> OrientationTestCases() {
   return {
       {
-          // No elevation along x
+          // #0 - No elevation along x
           LineString3d{{0., 2., 0.}, {100., 2., 0.}} /* left*/,
           LineString3d{{0., -2., 0.}, {100., -2., 0.}} /* right*/,
           std::nullopt /* center*/,
@@ -80,7 +80,7 @@ std::vector<OrientationTestCase> OrientationTestCases() {
           {{0., 0., 0.}, {0., 0., 0.}, {0., 0., 0.}} /* expected_rpy */
       },
       {
-          // No elevation along -x
+          // #1 - No elevation along -x
           LineString3d{{0., 2., 0.}, {-100., 2., 0.}} /* line string*/,
           LineString3d{{0., -2., 0.}, {-100., -2., 0.}} /* line string*/,
           std::nullopt /* center*/,
@@ -88,7 +88,7 @@ std::vector<OrientationTestCase> OrientationTestCases() {
           {{0., 0., M_PI}, {0., 0., M_PI}, {0., 0., M_PI}} /* expected_rpy */
       },
       {
-          // Linear Elevation
+          // #2 - Linear Elevation
           LineString3d{{0., 2., 0.}, {100., 2., 100.}} /* left*/,
           LineString3d{{0., -2., 0.}, {100., -2., 100.}} /* right*/,
           std::nullopt /* center*/,
@@ -96,7 +96,7 @@ std::vector<OrientationTestCase> OrientationTestCases() {
           {{0., -M_PI_4, 0.}} /* expected_rpy */
       },
       {
-          // Linear Elevation with negative yaw.
+          // #3 - Linear Elevation with negative yaw.
           LineString3d{{1., 1., 0.}, {1. + 70.71067811865476, 1. - 70.71067811865476, 100.}} /* left*/,
           LineString3d{{-1., -1., 0.}, {-1. + 70.71067811865476, -1. - 70.71067811865476, 100.}} /* right*/,
           std::nullopt /* center*/,
@@ -107,7 +107,7 @@ std::vector<OrientationTestCase> OrientationTestCases() {
           {{0., -M_PI_4, -M_PI_4}, {0., -M_PI_4, -M_PI_4}} /* expected_rpy */
       },
       {
-          // Increase elevation + plateau + decrease elevation.
+          // #4 - Increase elevation + plateau + decrease elevation.
           LineString3d{{0., 2., 0.}, {10., 2., 10.}, {20., 2., 10.}, {30., 2., 0.}} /* left*/,
           LineString3d{{0., -2., 0.}, {10., -2., 10.}, {20., -2., 10.}, {30., -2., 0.}} /* right*/,
           std::nullopt /* center*/,
@@ -115,7 +115,7 @@ std::vector<OrientationTestCase> OrientationTestCases() {
           {{0., -M_PI_4, 0.}, {0., 0., 0.}, {0., M_PI_4, 0.}} /* expected_rpy */
       },
       {
-          // Constant superelevation to the left.
+          // #5 - Constant superelevation to the left.
           LineString3d{{0., 2., 0.}, {100., 2., 0.}} /* left*/,
           LineString3d{{0., -2., 4.}, {100., -2., 4.}} /* right*/,
           std::nullopt /* center*/,
@@ -123,42 +123,65 @@ std::vector<OrientationTestCase> OrientationTestCases() {
           {{-M_PI_4, 0., 0.}, {-M_PI_4, 0., 0.}} /* expected_rpy */
       },
       {
-          // Constant superelevation to the right.
+          // #6 - Constant superelevation to the right.
           LineString3d{{0., 2., 4.}, {100., 2., 4.}} /* left*/,
           LineString3d{{0., -2., 0.}, {100., -2., 0.}} /* right*/,
           std::nullopt /* center*/,
           {0., 100.} /* p */,
           {{M_PI_4, 0., 0.}, {M_PI_4, 0., 0.}} /* expected_rpy */
       },
-      {
-          // Increasing superelevation
-          LineString3d{{0., 2., 0.}, {100., 1., -1.}} /* left*/,
-          LineString3d{{0., -2., 0.}, {100., 1., 1.}} /* right*/,
-          LineString3d{{0., 0., 0.}, {100., 0., 0.}} /* center*/,
-          {0., 100.} /* p */,
-          {{0., 0., 0.}, {-M_PI_2, 0., 0.}} /* expected_rpy */
-      },
   };
 }
 
 class OrientationTest : public ::testing::TestWithParam<OrientationTestCase> {
  public:
-  static constexpr double kTolerance{1e-12};
   OrientationTestCase case_ = GetParam();
+
+  virtual double GetTolerance() const {
+    static constexpr double kTolerance{1e-12};
+    return kTolerance;
+  }
+
+  void ExecuteOrientationTest() {
+    ASSERT_EQ(case_.p.size(), case_.expected_rpy.size()) << ">>>>> Test case is ill-formed.";
+    const LaneGeometry lane_geometry = case_.center.has_value()
+                                           ? LaneGeometry{case_.center.value(), case_.left, case_.right, 1e-3, 1.}
+                                           : LaneGeometry{case_.left, case_.right, 1e-3, 1.};
+    for (std::size_t i = 0; i < case_.p.size(); ++i) {
+      const auto rpy = lane_geometry.Orientation(case_.p[i]);
+      EXPECT_TRUE(maliput::math::test::CompareVectors(case_.expected_rpy[i].vector(), rpy.vector(), GetTolerance()));
+    }
+  }
 };
 
-TEST_P(OrientationTest, Test) {
-  ASSERT_EQ(case_.p.size(), case_.expected_rpy.size()) << ">>>>> Test case is ill-formed.";
-  const LaneGeometry lane_geometry = case_.center.has_value()
-                                         ? LaneGeometry{case_.center.value(), case_.left, case_.right, 1e-3, 1.}
-                                         : LaneGeometry{case_.left, case_.right, 1e-3, 1.};
-  for (std::size_t i = 0; i < case_.p.size(); ++i) {
-    const auto rpy = lane_geometry.Orientation(case_.p[i]);
-    EXPECT_TRUE(maliput::math::test::CompareVectors(case_.expected_rpy[i].vector(), rpy.vector(), kTolerance));
-  }
-}
+TEST_P(OrientationTest, Test) { ExecuteOrientationTest(); }
 
 INSTANTIATE_TEST_CASE_P(OrientationTestGroup, OrientationTest, ::testing::ValuesIn(OrientationTestCases()));
+
+std::vector<OrientationTestCase> OrientationTestInIncreasingSuperelevationCases() {
+  return {
+      {
+          LineString3d{{0., 2., 0.}, {100., 1., -1.}} /* left*/,
+          LineString3d{{0., -2., 0.}, {100., -1., 1.}} /* right*/,
+          LineString3d{{0., 0., 0.}, {100., 0., 0.}} /* center*/,
+          {0., 100.} /* p */,
+          {{0., 0., 0.}, {-M_PI_4, 0., 0.}} /* expected_rpy */
+      },
+  };
+}
+
+class OrientationTestInIncreasingSuperelevation : public OrientationTest {
+ public:
+  double GetTolerance() const override {
+    static constexpr double kTolerance{1e-4};
+    return kTolerance;
+  }
+};
+
+TEST_P(OrientationTestInIncreasingSuperelevation, Test) { ExecuteOrientationTest(); }
+
+INSTANTIATE_TEST_CASE_P(OrientationTestInIncreasingSuperelevationGroup, OrientationTestInIncreasingSuperelevation,
+                        ::testing::ValuesIn(OrientationTestInIncreasingSuperelevationCases()));
 
 struct WAndWInverseCase {
   LineString3d left{};
@@ -318,6 +341,7 @@ INSTANTIATE_TEST_CASE_P(WDotTestGroup, WDotTest, ::testing::ValuesIn(WDotCases()
 struct RBoundsCase {
   LineString3d left{};
   LineString3d right{};
+  std::optional<LineString3d> centerline{};
   double length{};
   std::vector<double> p{};
   std::vector<double> expected_left_p{};
@@ -331,6 +355,7 @@ std::vector<RBoundsCase> RBoundsCases() {
           // Straight lane.
           LineString3d{{0., 2., 0.}, {100., 2., 0.}} /* left */,
           LineString3d{{0., -2., 0.}, {100., -2., 0.}} /* right */,
+          std::nullopt,
           100. /* length */,
           {0., 50., 100.} /* p */,
           {0., 50., 100.} /* expected_left_p */,
@@ -342,26 +367,28 @@ std::vector<RBoundsCase> RBoundsCases() {
           // Right LineString with zero elevation.
           LineString3d{{0., 2., 0.}, {10., 2., 10.}} /* left */,
           LineString3d{{0., -2., 0.}, {10., -2., 0.}} /* right */,
-          // centerline: {0, 0, 0}, {5, 0, 0}, {10, 0, 5}
-          // length: 5.*(std::sqrt(2.) + 1.) = 12.071067811865476
-          12.071067811865476 /* length */,
-          {0., 2.5, 5., 7.5, 12.071067811865476} /* p */,
-          {0., 2.928932188134525, 5.85786437626905, 8.786796564403575, 14.142135623730951} /* expected_left_p */,
-          {0., 2.071067811865475, 4.14213562373095, 6.213203435596426, 10.} /* expected_right_p */,
-          {{-2., 2.},
-           {-2.6864458697336402, 2.045478629078747},
-           {-4.1070628975017831, 2.1762194944608613},
-           {-5.4419740342632519, 2.4671732743644945},
-           {-5.3851648071345037, 5.3851648071345037}} /* expected_r_bounds */
+          LineString3d{{0, 0, 0}, {5., 0., 2.5}, {10., 0., 5.}} /* center */,
+          // length: 5.*std::sqrt(5.)
+          11.180339887498949 /* length */,
+          {0., 11.180339887498949 / 2., 11.180339887498949} /* p */,
+          {0., 14.142135623730951 / 2., 14.142135623730951} /* expected_left_p */,
+          {0., 10. / 2., 10.} /* expected_right_p */,
+          {
+              {-2., 2.},
+              {-3.2015621187164243, 3.2015621187164243},
+              {-5.385164807134504, 5.385164807134504},
+          } /* expected_r_bounds */
       },
       {
           // Arc-like lane:
+          // For further information on this test case, see the following link:
+          // https://github.com/maliput/maliput_sparse/pull/46
           /*
-                  ______________
-                 /              \
-                /    ________    \
-               /    /        \    \
-              /    /          \    \
+                  _________
+                 /          \
+                /  ________  \
+               /  /        \  \
+              /  /          \  \
           */
           LineString3d{
               {0., 0., 0.},
@@ -372,15 +399,18 @@ std::vector<RBoundsCase> RBoundsCases() {
           LineString3d{{2., -2., 0.}, {5., 1., 0.}, {15., 1., 0.}, {18., -2., 0.}} /* right */,
           // centerline:
           // {1., -1., 0.}, {2.5, 0.5, 0.}, {5., 3., 0.}, {10., 3., 0.}, {15., 3., 0.}, {17.5, 0.5, 0.}, {19., -1., 0.}
+          std::nullopt,
           21.313708498984759 /* length */,
-          {0., 5.656854249492381, 10.656854249492381, 15.656854249492381, 21.313708498984759} /* p */,
-          {0., 6.407544820340815, 12.071067811865479, 17.73459080339014, 24.14213562373095} /* expected_left_p */,
-          {0., 4.906163678643947, 9.242640687119287, 13.579117695594627, 18.48528137423857} /* expected_right_p */,
-          {{-1.4142135623730951, 1.4142135623730951},
-           {-2.1071930999037169, 1.6011047227338844},
-           {-2., 2.},
-           {-2.1071930999037161, 1.6011047227338822},
-           {-1.4142135623730951, 1.4142135623730951}} /* expected_r_bounds */
+          {0., 3., 5.656854249492381, 10.656854249492381, 15.656854249492381} /* p */,
+          {0., 3., 5.656854249492381, 12.071067811865479, 18.48528137423857} /* expected_left_p */,
+          {0., 3., 4.242640687119285, 9.242640687119287, 14.242640687119284} /* expected_right_p */,
+          {
+              {-1.4142135623730951, 1.4142135623730951},
+              {-1.4142135623730951, 1.4142135623730951},
+              {-2., 1.4142135623730951},
+              {-2., 2.},
+              {-2., 1.4142135623730951},
+          } /* expected_r_bounds */
       },
   };
 }
@@ -398,7 +428,10 @@ TEST_P(RBoundsCaseTest, Test) {
   ASSERT_EQ(case_.p.size(), case_.expected_right_p.size()) << ">>>>> Test case is ill-formed.";
   ASSERT_EQ(case_.p.size(), case_.expected_r_bounds.size()) << ">>>>> Test case is ill-formed.";
 
-  const LaneGeometry lane_geometry{case_.left, case_.right, kLinearTolerance, kScaleLength};
+  const LaneGeometry lane_geometry =
+      case_.centerline.has_value()
+          ? LaneGeometry{case_.centerline.value(), case_.left, case_.right, kLinearTolerance, kScaleLength}
+          : LaneGeometry{case_.left, case_.right, kLinearTolerance, kScaleLength};
   ASSERT_DOUBLE_EQ(case_.length, lane_geometry.ArcLength());
   for (std::size_t i = 0; i < case_.p.size(); ++i) {
     const double p_left = lane_geometry.FromCenterPToLateralP(LaneGeometry::LineStringType::kLeftBoundary, case_.p[i]);

--- a/test/geometry/lane_geometry_test.cc
+++ b/test/geometry/lane_geometry_test.cc
@@ -135,6 +135,8 @@ std::vector<OrientationTestCase> OrientationTestCases() {
 
 class OrientationTest : public ::testing::TestWithParam<OrientationTestCase> {
  public:
+  static constexpr double kLinearTolerance{1e-3};
+  static constexpr double kScaleLength{1e-3};
   OrientationTestCase case_ = GetParam();
 
   virtual double GetTolerance() const {
@@ -144,9 +146,10 @@ class OrientationTest : public ::testing::TestWithParam<OrientationTestCase> {
 
   void ExecuteOrientationTest() {
     ASSERT_EQ(case_.p.size(), case_.expected_rpy.size()) << ">>>>> Test case is ill-formed.";
-    const LaneGeometry lane_geometry = case_.center.has_value()
-                                           ? LaneGeometry{case_.center.value(), case_.left, case_.right, 1e-3, 1.}
-                                           : LaneGeometry{case_.left, case_.right, 1e-3, 1.};
+    const LaneGeometry lane_geometry =
+        case_.center.has_value()
+            ? LaneGeometry{case_.center.value(), case_.left, case_.right, kLinearTolerance, kScaleLength}
+            : LaneGeometry{case_.left, case_.right, kLinearTolerance, kScaleLength};
     for (std::size_t i = 0; i < case_.p.size(); ++i) {
       const auto rpy = lane_geometry.Orientation(case_.p[i]);
       EXPECT_TRUE(maliput::math::test::CompareVectors(case_.expected_rpy[i].vector(), rpy.vector(), GetTolerance()));

--- a/test/geometry/utility/geometry_test.cc
+++ b/test/geometry/utility/geometry_test.cc
@@ -240,32 +240,32 @@ class GetBoundPointsAtPTest : public ::testing::Test {
 TEST_F(GetBoundPointsAtPTest, Test) {
   {
     const double p{0.};
-    const BoundPointsResult expected_result{line_string.begin(), line_string.begin() + 1, 0.};
-    const BoundPointsResult dut = GetBoundPointsAtP(line_string, p);
+    const BoundPointsResult3d expected_result{line_string.begin(), line_string.begin() + 1, 0.};
+    const BoundPointsResult3d dut = GetBoundPointsAtP(line_string, p);
     EXPECT_EQ(expected_result.first, dut.first);
     EXPECT_EQ(expected_result.second, dut.second);
     EXPECT_EQ(expected_result.length, dut.length);
   }
   {
     const double p{7.5};
-    const BoundPointsResult expected_result{line_string.begin() + 1, line_string.begin() + 2, 7.};
-    const BoundPointsResult dut = GetBoundPointsAtP(line_string, p);
+    const BoundPointsResult3d expected_result{line_string.begin() + 1, line_string.begin() + 2, 7.};
+    const BoundPointsResult3d dut = GetBoundPointsAtP(line_string, p);
     EXPECT_EQ(expected_result.first, dut.first);
     EXPECT_EQ(expected_result.second, dut.second);
     EXPECT_EQ(expected_result.length, dut.length);
   }
   {
     const double p{12.5};
-    const BoundPointsResult expected_result{line_string.begin() + 2, line_string.begin() + 3, 12.};
-    const BoundPointsResult dut = GetBoundPointsAtP(line_string, p);
+    const BoundPointsResult3d expected_result{line_string.begin() + 2, line_string.begin() + 3, 12.};
+    const BoundPointsResult3d dut = GetBoundPointsAtP(line_string, p);
     EXPECT_EQ(expected_result.first, dut.first);
     EXPECT_EQ(expected_result.second, dut.second);
     EXPECT_EQ(expected_result.length, dut.length);
   }
   {
     const double p{19.5};
-    const BoundPointsResult expected_result{line_string.begin() + 3, line_string.begin() + 4, 19.};
-    const BoundPointsResult dut = GetBoundPointsAtP(line_string, p);
+    const BoundPointsResult3d expected_result{line_string.begin() + 3, line_string.begin() + 4, 19.};
+    const BoundPointsResult3d dut = GetBoundPointsAtP(line_string, p);
     EXPECT_EQ(expected_result.first, dut.first);
     EXPECT_EQ(expected_result.second, dut.second);
     EXPECT_EQ(expected_result.length, dut.length);
@@ -388,13 +388,13 @@ TEST_P(Get2DHeadingAtPTest, Test) {
 
 INSTANTIATE_TEST_CASE_P(Get2DHeadingAtPTestGroup, Get2DHeadingAtPTest, ::testing::ValuesIn(HeadingTestCases()));
 
-struct GetClosestPointTestCase {
+struct GetClosestPointToSegmentTestCase {
   std::pair<maliput::math::Vector3, maliput::math::Vector3> segment;
   std::vector<maliput::math::Vector3> eval_points;
-  std::vector<ClosestPointResult> expected_closest{};
+  std::vector<ClosestPointResult3d> expected_closest{};
 };
 
-std::vector<GetClosestPointTestCase> GetClosestPointTestCases() {
+std::vector<GetClosestPointToSegmentTestCase> GetClosestPointToSegmentTestCases() {
   return {
       {{{0., 0., 0.}, {10., 0., 0.}} /* segment */,
        {{5., 5., 0.}, {-5., 5., 0.}, {10., 5., 0.}, {15., 5., 0.}} /* eval points */,
@@ -430,28 +430,29 @@ std::vector<GetClosestPointTestCase> GetClosestPointTestCases() {
   };
 }
 
-class GetClosestPointTest : public ::testing::TestWithParam<GetClosestPointTestCase> {
+class GetClosestPointToSegmentTest : public ::testing::TestWithParam<GetClosestPointToSegmentTestCase> {
  public:
   static constexpr double kTolerance{1e-12};
-  GetClosestPointTestCase case_ = GetParam();
+  GetClosestPointToSegmentTestCase case_ = GetParam();
 };
 
-TEST_P(GetClosestPointTest, Test) {
+TEST_P(GetClosestPointToSegmentTest, Test) {
   ASSERT_EQ(case_.eval_points.size(), case_.expected_closest.size()) << ">>>>> Test case is ill-formed.";
   for (std::size_t i = 0; i < case_.eval_points.size(); ++i) {
-    const auto dut = GetClosestPoint(case_.segment, case_.eval_points[i]);
+    const auto dut = GetClosestPointToSegment(case_.segment, case_.eval_points[i]);
     EXPECT_NEAR(case_.expected_closest[i].p, dut.p, kTolerance);
     EXPECT_TRUE(maliput::math::test::CompareVectors(case_.expected_closest[i].point, dut.point, kTolerance));
     EXPECT_NEAR(case_.expected_closest[i].distance, dut.distance, kTolerance);
   }
 }
 
-INSTANTIATE_TEST_CASE_P(GetClosestPointTestGroup, GetClosestPointTest, ::testing::ValuesIn(GetClosestPointTestCases()));
+INSTANTIATE_TEST_CASE_P(GetClosestPointToSegmentTestGroup, GetClosestPointToSegmentTest,
+                        ::testing::ValuesIn(GetClosestPointToSegmentTestCases()));
 
 struct GetClosestPointLineStringTestCase {
   LineString3d line_string;
   std::vector<maliput::math::Vector3> eval_points;
-  std::vector<ClosestPointResult> expected_closest{};
+  std::vector<ClosestPointResult3d> expected_closest{};
 };
 
 std::vector<GetClosestPointLineStringTestCase> GetClosestPointLineStringTestCases() {
@@ -503,6 +504,49 @@ TEST_P(GetClosestPointLineStringTest, Test) {
 
 INSTANTIATE_TEST_CASE_P(GetClosestPointLineStringTestGroup, GetClosestPointLineStringTest,
                         ::testing::ValuesIn(GetClosestPointLineStringTestCases()));
+
+std::vector<GetClosestPointLineStringTestCase> GetClosestPointIn2dLineStringTestCases() {
+  return {
+      // Increasing in elevation line string and eval points are below(in Z) the line string.
+      //
+      // ^ z
+      // |         *{10., 0., 10.}
+      // |       /
+      // |     /
+      // |   /
+      // | /
+      // |-----*-------> x
+      //       {5., 0., 0.} (eval point)
+      // Because of the 2d projection the closest point is the one in the half of the line segment. Which is the desired
+      // value.
+      //
+      {LineString3d{{0., 0., 0.}, {10., 0., 10.}} /* line_string */,
+       {{5., 0., 0.}, {5., -2., 0.}} /* eval points */,
+       {
+           {10 * std::sqrt(2.) / 2., {5., 0., 5.}, 5.},                /* expected: p, point, distance */
+           {10 * std::sqrt(2.) / 2., {5., 0., 5.}, 5.385164807134504}, /* expected: p, point, distance */
+       }},
+  };
+}
+
+class GetClosestPointIn2dLineStringTest : public ::testing::TestWithParam<GetClosestPointLineStringTestCase> {
+ public:
+  static constexpr double kTolerance{1e-12};
+  GetClosestPointLineStringTestCase case_ = GetParam();
+};
+
+TEST_P(GetClosestPointIn2dLineStringTest, Test) {
+  ASSERT_EQ(case_.eval_points.size(), case_.expected_closest.size()) << ">>>>> Test case is ill-formed.";
+  for (std::size_t i = 0; i < case_.eval_points.size(); ++i) {
+    const auto dut = GetClosestPointUsing2dProjection(case_.line_string, case_.eval_points[i]);
+    EXPECT_NEAR(case_.expected_closest[i].p, dut.p, kTolerance);
+    EXPECT_TRUE(maliput::math::test::CompareVectors(case_.expected_closest[i].point, dut.point, kTolerance));
+    EXPECT_NEAR(case_.expected_closest[i].distance, dut.distance, kTolerance);
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(GetClosestPointIn2dLineStringTestGroup, GetClosestPointIn2dLineStringTest,
+                        ::testing::ValuesIn(GetClosestPointIn2dLineStringTestCases()));
 
 struct ComputeDistanceTestCase {
   LineString3d lhs;


### PR DESCRIPTION
# 🦟 Bug fix

Related to #39 

## Summary

#39 Describes an issue that is evidenced when calculating the RBounds.
Intrinsically, this issue comes from the calculation of the equivalent p: this is the p in the left or right linestring that matches with the p in the centerline.

At the moment the equivalent p has been calculated by scaling the centerline p by the ratio of centerline length and boundary length. (Causing the issue in #39)

In this PR a new approach is given: **For a given point in the centerline, the equivalent p in the boundaries will be given by the closest point(boundary to centerline)**

Using this approach the issue of the RBounds calculation is solved, being consistent no matter the shape of the lane:

![image](https://user-images.githubusercontent.com/53065142/209859497-a44f1891-e5d1-45cf-b817-868a296465a2.png)
(Compare it with the case in #39 )

Pros:
 - This approach doesn't accumulate error as the prior does given that the closest point is calculated for each centerline p.
 - Solves the issue for the RBound calculation for any shape for roads.
 
Cons:
- The time for creating the meshes for the `s_shape_road` was doubled. From 36sec to 70sec(we should improve overall performance tho)
- when equivalent p is wanted to be calculated on a change of direction, an error might be added: this is minimized by sampling the road correctly and avoiding big discrete jumps in direction. For example:
   ![image](https://user-images.githubusercontent.com/53065142/209861104-0788143a-e2c0-4595-8825-7dd1a2c6e84c.png)

 




## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)