### PR TITLE
Implements range validator for the geometry::utils methods.

### DIFF
--- a/include/maliput_sparse/geometry/utility/geometry.h
+++ b/include/maliput_sparse/geometry/utility/geometry.h
@@ -101,7 +101,8 @@ double GetSlopeAtP(const LineString3d& line_string, double p, double tolerance);
 /// @param tolerance tolerance.
 /// @throws maliput::common::assertion_error When `p ∉ [0., line_string.length()]`.
 template <typename CoordinateT = maliput::math::Vector3>
-BoundPointsResult<CoordinateT> GetBoundPointsAtP(const LineString<CoordinateT>& line_string, double p, , double tolerance);
+BoundPointsResult<CoordinateT> GetBoundPointsAtP(const LineString<CoordinateT>& line_string, double p,
+                                                 double tolerance);
 
 /// Returns the heading of a @p line_string for a given @p p .
 /// @param line_string LineString to be computed the heading from.
@@ -128,7 +129,6 @@ maliput::math::Vector3 GetTangentAtP(const LineString3d& line_string, double p, 
 /// Gets the closest point in the @p segment to the given @p xyz point.
 /// @tparam CoordinateT The coordinate type of the @p segment .
 /// @param segment Segment to be computed the closest point from.
-/// @param xyz Point to be computed the closest point to.
 /// @param coordinate Point to be computed the closest point to.
 /// @param tolerance tolerance.
 /// @return A ClosestPointResult struct containing the closest point, the distance between the closest point and @p xyz
@@ -143,7 +143,8 @@ ClosestPointResult<CoordinateT> GetClosestPointToSegment(const std::pair<Coordin
 /// @param tolerance tolerance.
 /// @return A ClosestPointResult struct containing the closest point, the distance between the closest point and @p xyz
 /// and the p coordinate in the LineString3d matching the closest point.
-ClosestPointResult3d GetClosestPoint(const LineString3d& line_string, const maliput::math::Vector3& xyz, double tolerance);
+ClosestPointResult3d GetClosestPoint(const LineString3d& line_string, const maliput::math::Vector3& xyz,
+                                     double tolerance);
 
 /// Gets the closest point in the @p line_string to the given @p xyz point.
 /// @details This method is similar to #ref GetClosestPoint, but it first projects the @p line_string and the @p xyz on
@@ -151,9 +152,10 @@ ClosestPointResult3d GetClosestPoint(const LineString3d& line_string, const mali
 /// recovered from the @p line_string and the rest of the ClosestPointResult3d struct is filled.
 /// @param line_string LineString3d to be computed the closest point from.
 /// @param xyz Point to be computed the closest point to.
+/// @param tolerance Tolerance.
 /// @return A ClosestPointResult struct containing the closest point, the distance between the closest point and @p xyz
 ClosestPointResult3d GetClosestPointUsing2dProjection(const LineString3d& line_string,
-                                                      const maliput::math::Vector3& xyz);
+                                                      const maliput::math::Vector3& xyz, double tolerance);
 
 /// Computes the distance between two LineString3d.
 /// The distance is calculated as the sum of distances between corresponding points between both line strings divided by

--- a/include/maliput_sparse/geometry/utility/geometry.h
+++ b/include/maliput_sparse/geometry/utility/geometry.h
@@ -68,57 +68,66 @@ LineString3d ComputeCenterline3d(const LineString3d& left, const LineString3d& r
 /// first point.
 /// @param line_string the line_string to iterate.
 /// @param p distance along line_string.
+/// @param tolerance tolerance.
 /// @return The interpolated point (a new point if not perfectly matching).
-maliput::math::Vector3 InterpolatedPointAtP(const LineString3d& line_string, double p);
+maliput::math::Vector3 InterpolatedPointAtP(const LineString3d& line_string, double p, double tolerance);
 
 /// Returns the slope of a @p line_string for a given @p p .
 /// The slope is calculated as the variation in `z` divided by the variation in the `xy` plane.
 /// The result is expected to be contained within (-inf., inf.).
 /// @param line_string LineString to be computed the slope from.
 /// @param p P parameter at which compute the slope.
+/// @param tolerance tolerance.
 /// @throws maliput::common::assertion_error When `p ∉ [0., line_string.length()]`.
 /// @throws maliput::common::assertion_error When the points that confine @p p are equal.
-double GetSlopeAtP(const LineString3d& line_string, double p);
+double GetSlopeAtP(const LineString3d& line_string, double p, double tolerance);
 
 /// Obtains the points that confines @p p in the @p line_string .
 /// @param line_string LineString.
 /// @param p P parameter.
+/// @param tolerance tolerance.
 /// @throws maliput::common::assertion_error When `p ∉ [0., line_string.length()]`.
-BoundPointsResult GetBoundPointsAtP(const LineString3d& line_string, double p);
+BoundPointsResult GetBoundPointsAtP(const LineString3d& line_string, double p, double tolerance);
 
 /// Returns the heading of a @p line_string for a given @p p .
 /// @param line_string LineString to be computed the heading from.
 /// @param p P parameter at which compute the heading.
+/// @param tolerance tolerance.
 /// @throws maliput::common::assertion_error When `p ∉ [0., line_string.length()]`.
-double Get2DHeadingAtP(const LineString3d& line_string, double p);
+double Get2DHeadingAtP(const LineString3d& line_string, double p, double tolerance);
 
 /// Returns the 2d-tangent of a @p line_string for a given @p p .
 /// The tangent is calculated from the @p line_string projected on the xy plane.
 /// @param line_string LineString to be computed the 2d-tangent from.
 /// @param p P parameter at which compute the 2d-tangent.
+/// @param tolerance tolerance.
 /// @throws maliput::common::assertion_error When `p ∉ [0., line_string.length()]`.
-maliput::math::Vector2 Get2DTangentAtP(const LineString3d& line_string, double p);
+maliput::math::Vector2 Get2DTangentAtP(const LineString3d& line_string, double p, double tolerance);
 
 /// Returns the 3d-tangent of a @p line_string for a given @p p .
 /// @param line_string LineString to be computed the 3d-tangent from.
 /// @param p P parameter at which compute the 3d-tangent.
+/// @param tolerance tolerance.
 /// @throws maliput::common::assertion_error When `p ∉ [0., line_string.length()]`.
-maliput::math::Vector3 GetTangentAtP(const LineString3d& line_string, double p);
+maliput::math::Vector3 GetTangentAtP(const LineString3d& line_string, double p, double tolerance);
 
 /// Gets the closest point in the @p segment to the given @p xyz point.
 /// @param segment Segment to be computed the closest point from.
 /// @param xyz Point to be computed the closest point to.
+/// @param tolerance tolerance.
 /// @return A ClosestPointResult struct containing the closest point, the distance between the closest point and @p xyz
 /// and the p coordinate in the segment matching the closest point.
 ClosestPointResult GetClosestPoint(const std::pair<maliput::math::Vector3, maliput::math::Vector3>& segment,
-                                   const maliput::math::Vector3& xyz);
+                                   const maliput::math::Vector3& xyz, double tolerance);
 
 /// Gets the closest point in the @p line_string to the given @p xyz point.
 /// @param line_string LineString3d to be computed the closest point from.
 /// @param xyz Point to be computed the closest point to.
+/// @param tolerance tolerance.
 /// @return A ClosestPointResult struct containing the closest point, the distance between the closest point and @p xyz
 /// and the p coordinate in the LineString3d matching the closest point.
-ClosestPointResult GetClosestPoint(const LineString3d& line_string, const maliput::math::Vector3& xyz);
+ClosestPointResult GetClosestPoint(const LineString3d& line_string, const maliput::math::Vector3& xyz,
+                                   double tolerance);
 
 /// Computes the distance between two LineString3d.
 /// The distance is calculated as the sum of distances between corresponding points between both line strings divided by
@@ -134,8 +143,9 @@ ClosestPointResult GetClosestPoint(const LineString3d& line_string, const malipu
 ///
 /// @param lhs A LineString3d.
 /// @param rhs A LineString3d.
+/// @param tolerance tolerance.
 /// @return The distance between the two line strings defined as above.
-double ComputeDistance(const LineString3d& lhs, const LineString3d& rhs);
+double ComputeDistance(const LineString3d& lhs, const LineString3d& rhs, double tolerance);
 
 }  // namespace utility
 }  // namespace geometry

--- a/src/geometry/lane_geometry.cc
+++ b/src/geometry/lane_geometry.cc
@@ -57,7 +57,7 @@ double LaneGeometry::ArcLength() const { return centerline_.length(); }
 maliput::math::Vector3 LaneGeometry::W(const maliput::math::Vector3& prh) const {
   const double p = range_validator_(prh.x());
   // Obtains the point on the centerline (p, 0, 0).
-  const maliput::math::Vector3 on_centerline_point = utility::InterpolatedPointAtP(centerline_, p);
+  const maliput::math::Vector3 on_centerline_point = utility::InterpolatedPointAtP(centerline_, p, linear_tolerance_);
   // Calculates orientation of (p,r,h) basis at (p,0,0).
   const maliput::math::RollPitchYaw rpy = Orientation(p);
   // Rotates (0,r,h) and sums with mapped (p,0,0).
@@ -65,7 +65,7 @@ maliput::math::Vector3 LaneGeometry::W(const maliput::math::Vector3& prh) const 
 }
 
 maliput::math::Vector3 LaneGeometry::WDot(double p) const {
-  return utility::GetTangentAtP(centerline_, range_validator_(p));
+  return utility::GetTangentAtP(centerline_, range_validator_(p), linear_tolerance_);
 };
 
 maliput::math::Vector3 LaneGeometry::WDot(const maliput::math::Vector3& prh) const {
@@ -105,10 +105,10 @@ maliput::math::RollPitchYaw LaneGeometry::Orientation(double p) const {
   const double ground_diff = maliput::math::Vector2(diff.x(), diff.y()).norm();
   const double elevation_diff = diff.z();
   const double superelevation = std::atan2(elevation_diff, ground_diff);
-  return maliput::math::RollPitchYaw(
-      superelevation,
-      -std::atan2(utility::GetSlopeAtP(centerline_, p), utility::Get2DTangentAtP(centerline_, p).norm()),
-      utility::Get2DHeadingAtP(centerline_, p));
+  return maliput::math::RollPitchYaw(superelevation,
+                                     -std::atan2(utility::GetSlopeAtP(centerline_, p, linear_tolerance_),
+                                                 utility::Get2DTangentAtP(centerline_, p, linear_tolerance_).norm()),
+                                     utility::Get2DHeadingAtP(centerline_, p, linear_tolerance_));
 }
 
 maliput::math::RollPitchYaw LaneGeometry::Orientation(const maliput::math::Vector3& prh) const {
@@ -117,7 +117,8 @@ maliput::math::RollPitchYaw LaneGeometry::Orientation(const maliput::math::Vecto
 }
 
 maliput::math::Vector3 LaneGeometry::WInverse(const maliput::math::Vector3& xyz) const {
-  const utility::ClosestPointResult closest_centerline_point = utility::GetClosestPoint(centerline_, xyz);
+  const utility::ClosestPointResult closest_centerline_point =
+      utility::GetClosestPoint(centerline_, xyz, linear_tolerance_);
   const double p = closest_centerline_point.p;
 
   const maliput::math::Vector3 d_xyz = xyz - closest_centerline_point.point;
@@ -139,7 +140,7 @@ maliput::api::RBounds LaneGeometry::RBounds(double p) const {
   // Get distance from centerline to left and right.
   const maliput::math::Vector3 on_left = ToLateralPos(LineStringType::kLeftBoundary, p);
   const maliput::math::Vector3 on_right = ToLateralPos(LineStringType::kRightBoundary, p);
-  const maliput::math::Vector3 on_centerline = utility::InterpolatedPointAtP(centerline_, p);
+  const maliput::math::Vector3 on_centerline = utility::InterpolatedPointAtP(centerline_, p, linear_tolerance_);
   return {-(on_right - on_centerline).norm(), (on_left - on_centerline).norm()};
 }
 
@@ -157,7 +158,8 @@ maliput::math::Vector3 LaneGeometry::ToLateralPos(const LineStringType& line_str
   p = range_validator_(p);
   MALIPUT_THROW_UNLESS(line_string_type != LineStringType::kCenterLine);
   const double p_lateral = FromCenterPToLateralP(line_string_type, p);
-  return utility::InterpolatedPointAtP(line_string_type == LineStringType::kLeftBoundary ? left_ : right_, p_lateral);
+  return utility::InterpolatedPointAtP(line_string_type == LineStringType::kLeftBoundary ? left_ : right_, p_lateral,
+                                       linear_tolerance_);
 }
 
 }  // namespace geometry

--- a/src/geometry/lane_geometry.cc
+++ b/src/geometry/lane_geometry.cc
@@ -147,10 +147,10 @@ maliput::api::RBounds LaneGeometry::RBounds(double p) const {
 double LaneGeometry::FromCenterPToLateralP(const LineStringType& line_string_type, double p) const {
   p = range_validator_(p);
   MALIPUT_THROW_UNLESS(line_string_type != LineStringType::kCenterLine);
-  const maliput::math::Vector3 point_at_p = utility::InterpolatedPointAtP(centerline_, p);
+  const maliput::math::Vector3 point_at_p = utility::InterpolatedPointAtP(centerline_, p, linear_tolerance_);
   // The lateral p is the one that matches closest point in the lateral to the centerline at p.
   const utility::ClosestPointResult closest_to_point = utility::GetClosestPointUsing2dProjection(
-      line_string_type == LineStringType::kLeftBoundary ? left_ : right_, point_at_p);
+      line_string_type == LineStringType::kLeftBoundary ? left_ : right_, point_at_p, linear_tolerance_);
   return closest_to_point.p;
 }
 

--- a/src/parser/validator.cc
+++ b/src/parser/validator.cc
@@ -53,7 +53,7 @@ static constexpr bool kRight{!kLeft};
 bool AreAdjacent(const Lane& lane, const Lane& adjacent_lane, bool left, double tolerance) {
   const auto line_string_a = left ? lane.left : lane.right;
   const auto line_string_b = left ? adjacent_lane.right : adjacent_lane.left;
-  const double distance = geometry::utility::ComputeDistance(line_string_a, line_string_b);
+  const double distance = geometry::utility::ComputeDistance(line_string_a, line_string_b, tolerance);
   return distance <= tolerance;
 }
 

--- a/test/geometry/utility/geometry_test.cc
+++ b/test/geometry/utility/geometry_test.cc
@@ -213,19 +213,20 @@ class InterpolatedPointAtPTest : public ::testing::TestWithParam<LineStringPoint
 };
 
 TEST_P(InterpolatedPointAtPTest, Test) {
-  const auto dut = InterpolatedPointAtP(line_string_point_at_p_case_.line_string, line_string_point_at_p_case_.p);
+  const auto dut =
+      InterpolatedPointAtP(line_string_point_at_p_case_.line_string, line_string_point_at_p_case_.p, kTolerance);
   EXPECT_TRUE(maliput::math::test::CompareVectors(line_string_point_at_p_case_.expected_point, dut, kTolerance));
 }
 
 TEST_P(InterpolatedPointAtPTest, NegativeP) {
   const double negative_p{-1.};
-  const auto dut = InterpolatedPointAtP(line_string_point_at_p_case_.line_string, negative_p);
+  const auto dut = InterpolatedPointAtP(line_string_point_at_p_case_.line_string, negative_p, kTolerance);
   EXPECT_EQ(line_string_point_at_p_case_.line_string.first(), dut);
 }
 
 TEST_P(InterpolatedPointAtPTest, ExceededP) {
   const double exceeded_p{line_string_point_at_p_case_.line_string.length() + 1};
-  const auto dut = InterpolatedPointAtP(line_string_point_at_p_case_.line_string, exceeded_p);
+  const auto dut = InterpolatedPointAtP(line_string_point_at_p_case_.line_string, exceeded_p, kTolerance);
   EXPECT_EQ(line_string_point_at_p_case_.line_string.last(), dut);
 }
 
@@ -234,6 +235,7 @@ INSTANTIATE_TEST_CASE_P(InterpolatedPointAtPTestGroup, InterpolatedPointAtPTest,
 
 class GetBoundPointsAtPTest : public ::testing::Test {
  public:
+  static constexpr double kTolerance{1e-12};
   const LineString3d line_string{{0., 0., 0.}, {6., 3., 2.}, {10., 6., 2.}, {16., 9., 4.}, {10., 6., 2.}};
 };
 
@@ -241,7 +243,7 @@ TEST_F(GetBoundPointsAtPTest, Test) {
   {
     const double p{0.};
     const BoundPointsResult expected_result{line_string.begin(), line_string.begin() + 1, 0.};
-    const BoundPointsResult dut = GetBoundPointsAtP(line_string, p);
+    const BoundPointsResult dut = GetBoundPointsAtP(line_string, p, kTolerance);
     EXPECT_EQ(expected_result.first, dut.first);
     EXPECT_EQ(expected_result.second, dut.second);
     EXPECT_EQ(expected_result.length, dut.length);
@@ -249,7 +251,7 @@ TEST_F(GetBoundPointsAtPTest, Test) {
   {
     const double p{7.5};
     const BoundPointsResult expected_result{line_string.begin() + 1, line_string.begin() + 2, 7.};
-    const BoundPointsResult dut = GetBoundPointsAtP(line_string, p);
+    const BoundPointsResult dut = GetBoundPointsAtP(line_string, p, kTolerance);
     EXPECT_EQ(expected_result.first, dut.first);
     EXPECT_EQ(expected_result.second, dut.second);
     EXPECT_EQ(expected_result.length, dut.length);
@@ -257,7 +259,7 @@ TEST_F(GetBoundPointsAtPTest, Test) {
   {
     const double p{12.5};
     const BoundPointsResult expected_result{line_string.begin() + 2, line_string.begin() + 3, 12.};
-    const BoundPointsResult dut = GetBoundPointsAtP(line_string, p);
+    const BoundPointsResult dut = GetBoundPointsAtP(line_string, p, kTolerance);
     EXPECT_EQ(expected_result.first, dut.first);
     EXPECT_EQ(expected_result.second, dut.second);
     EXPECT_EQ(expected_result.length, dut.length);
@@ -265,7 +267,7 @@ TEST_F(GetBoundPointsAtPTest, Test) {
   {
     const double p{19.5};
     const BoundPointsResult expected_result{line_string.begin() + 3, line_string.begin() + 4, 19.};
-    const BoundPointsResult dut = GetBoundPointsAtP(line_string, p);
+    const BoundPointsResult dut = GetBoundPointsAtP(line_string, p, kTolerance);
     EXPECT_EQ(expected_result.first, dut.first);
     EXPECT_EQ(expected_result.second, dut.second);
     EXPECT_EQ(expected_result.length, dut.length);
@@ -316,25 +318,28 @@ class GetSlopeAtPTest : public ::testing::TestWithParam<SlopeTestCase> {
 TEST_P(GetSlopeAtPTest, Test) {
   ASSERT_EQ(case_.p.size(), case_.expected_slopes.size()) << ">>>>> Test case is ill-formed.";
   for (std::size_t i = 0; i < case_.p.size(); ++i) {
-    const double dut = GetSlopeAtP(case_.line_string, case_.p[i]);
+    const double dut = GetSlopeAtP(case_.line_string, case_.p[i], kTolerance);
     EXPECT_DOUBLE_EQ(case_.expected_slopes[i], dut);
   }
 }
 
 INSTANTIATE_TEST_CASE_P(GetSlopeAtPTestGroup, GetSlopeAtPTest, ::testing::ValuesIn(SlopeTestCases()));
 
-class GetSlopeAtPSpecialCasesTest : public testing::Test {};
+class GetSlopeAtPSpecialCasesTest : public testing::Test {
+ public:
+  static constexpr double kTolerance{1e-12};
+};
 
 TEST_F(GetSlopeAtPSpecialCasesTest, Throw) {
   const LineString3d kNoLength{{0., 0., 0.}, {0., 0., 0.}};
-  EXPECT_THROW(GetSlopeAtP(kNoLength, 0.), maliput::common::assertion_error);
+  EXPECT_THROW(GetSlopeAtP(kNoLength, 0., kTolerance), maliput::common::assertion_error);
 }
 
 TEST_F(GetSlopeAtPSpecialCasesTest, InfinitySlope) {
   const double inf{std::numeric_limits<double>::infinity()};
   const LineString3d kOnlyZ{{0., 0., 0.}, {0., 0., 100.}, {0., 0., 0.}};
-  EXPECT_EQ(inf, GetSlopeAtP(kOnlyZ, 50.));
-  EXPECT_EQ(-inf, GetSlopeAtP(kOnlyZ, 150.));
+  EXPECT_EQ(inf, GetSlopeAtP(kOnlyZ, 50., kTolerance));
+  EXPECT_EQ(-inf, GetSlopeAtP(kOnlyZ, 150., kTolerance));
 }
 
 struct HeadingTestCase {
@@ -381,7 +386,7 @@ class Get2DHeadingAtPTest : public ::testing::TestWithParam<HeadingTestCase> {
 TEST_P(Get2DHeadingAtPTest, Test) {
   ASSERT_EQ(case_.p.size(), case_.expected_headings.size()) << ">>>>> Test case is ill-formed.";
   for (std::size_t i = 0; i < case_.p.size(); ++i) {
-    const double dut = Get2DHeadingAtP(case_.line_string, case_.p[i]);
+    const double dut = Get2DHeadingAtP(case_.line_string, case_.p[i], kTolerance);
     EXPECT_DOUBLE_EQ(case_.expected_headings[i], dut);
   }
 }
@@ -439,7 +444,7 @@ class GetClosestPointTest : public ::testing::TestWithParam<GetClosestPointTestC
 TEST_P(GetClosestPointTest, Test) {
   ASSERT_EQ(case_.eval_points.size(), case_.expected_closest.size()) << ">>>>> Test case is ill-formed.";
   for (std::size_t i = 0; i < case_.eval_points.size(); ++i) {
-    const auto dut = GetClosestPoint(case_.segment, case_.eval_points[i]);
+    const auto dut = GetClosestPoint(case_.segment, case_.eval_points[i], kTolerance);
     EXPECT_NEAR(case_.expected_closest[i].p, dut.p, kTolerance);
     EXPECT_TRUE(maliput::math::test::CompareVectors(case_.expected_closest[i].point, dut.point, kTolerance));
     EXPECT_NEAR(case_.expected_closest[i].distance, dut.distance, kTolerance);
@@ -494,7 +499,7 @@ class GetClosestPointLineStringTest : public ::testing::TestWithParam<GetClosest
 TEST_P(GetClosestPointLineStringTest, Test) {
   ASSERT_EQ(case_.eval_points.size(), case_.expected_closest.size()) << ">>>>> Test case is ill-formed.";
   for (std::size_t i = 0; i < case_.eval_points.size(); ++i) {
-    const auto dut = GetClosestPoint(case_.line_string, case_.eval_points[i]);
+    const auto dut = GetClosestPoint(case_.line_string, case_.eval_points[i], kTolerance);
     EXPECT_NEAR(case_.expected_closest[i].p, dut.p, kTolerance);
     EXPECT_TRUE(maliput::math::test::CompareVectors(case_.expected_closest[i].point, dut.point, kTolerance));
     EXPECT_NEAR(case_.expected_closest[i].distance, dut.distance, kTolerance);
@@ -539,7 +544,7 @@ class ComputeDistanceTest : public ::testing::TestWithParam<ComputeDistanceTestC
 };
 
 TEST_P(ComputeDistanceTest, Test) {
-  const auto dut = ComputeDistance(case_.lhs, case_.rhs);
+  const auto dut = ComputeDistance(case_.lhs, case_.rhs, kTolerance);
   EXPECT_NEAR(case_.expected_distance, dut, kTolerance);
 }
 

--- a/test/geometry/utility/geometry_test.cc
+++ b/test/geometry/utility/geometry_test.cc
@@ -543,7 +543,7 @@ class GetClosestPointIn2dLineStringTest : public ::testing::TestWithParam<GetClo
 TEST_P(GetClosestPointIn2dLineStringTest, Test) {
   ASSERT_EQ(case_.eval_points.size(), case_.expected_closest.size()) << ">>>>> Test case is ill-formed.";
   for (std::size_t i = 0; i < case_.eval_points.size(); ++i) {
-    const auto dut = GetClosestPointUsing2dProjection(case_.line_string, case_.eval_points[i]);
+    const auto dut = GetClosestPointUsing2dProjection(case_.line_string, case_.eval_points[i], kTolerance);
     EXPECT_NEAR(case_.expected_closest[i].p, dut.p, kTolerance);
     EXPECT_TRUE(maliput::math::test::CompareVectors(case_.expected_closest[i].point, dut.point, kTolerance));
     EXPECT_NEAR(case_.expected_closest[i].distance, dut.distance, kTolerance);


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/maliput/delphyne_demos/issues/57

## Summary
Implements range validator for the `geometry::utility` methods

This solves a numeric issue when using maliput_osm with the arc_lane_dense map.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
