### PR TITLE
Fixes bug due to segments with zero length.

### DIFF
--- a/src/geometry/utility/geometry.cc
+++ b/src/geometry/utility/geometry.cc
@@ -389,6 +389,8 @@ ClosestPointResult3d GetClosestPointUsing2dProjection(const LineString3d& line_s
   double length{};
   for (auto first = line_string.begin(), second = std::next(line_string.begin()); second != line_string.end();
        ++first, ++second) {
+    // If points are under numeric tolerance, skip segment.
+    if ((*first - *second).norm() < kEpsilon) continue;
     const maliput::math::Vector2 first_2d = To2D(*first);
     const maliput::math::Vector2 second_2d = To2D(*second);
     const maliput::math::Vector2 xy = To2D(xyz);


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

#46 Introduces an error due to missing discarding the segments that are close to zero (under an minimal epsilon)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
