### PR TITLE
Precomputes linestring's segments intervals

### DIFF
--- a/include/maliput_sparse/geometry/line_string.h
+++ b/include/maliput_sparse/geometry/line_string.h
@@ -77,6 +77,8 @@ class LineString final {
 
   struct Segment {
     struct Interval {
+      // Interval() = default;
+
       /// Creates a Interval.
       /// @param min_in Is the minimum value of the interval.
       /// @param max_in Is the maximum value of the interval.
@@ -97,13 +99,13 @@ class LineString final {
         }
       }
 
-      const double min{};
-      const double max{};
+      double min{};
+      double max{};
     };
 
-    const std::size_t idx_start;
-    const std::size_t idx_end;
-    const Segment::Interval p_interval;
+    std::size_t idx_start;
+    std::size_t idx_end;
+    Segment::Interval p_interval;
   };
 
   using Segments = std::map<typename Segment::Interval, Segment>;

--- a/include/maliput_sparse/geometry/line_string.h
+++ b/include/maliput_sparse/geometry/line_string.h
@@ -101,8 +101,8 @@ class LineString final {
       const double max{};
     };
 
-    const const_iterator start;
-    const const_iterator end;
+    const std::size_t idx_start;
+    const std::size_t idx_end;
     const Segment::Interval p_interval;
   };
 
@@ -138,10 +138,10 @@ class LineString final {
     MALIPUT_THROW_UNLESS(coordinates_.size() > 1);
     // Fill up the segments collection
     double p = 0;
-    for (auto it = coordinates_.cbegin(); it != coordinates_.cend() - 1; ++it) {
-      const double segment_length = DistanceFunction()(*it, *(it + 1));
+    for (std::size_t idx{}; idx < coordinates_.size() - 1; ++idx) {
+      const double segment_length = DistanceFunction()(coordinates_[idx], coordinates_[idx + 1]);
       const typename Segment::Interval interval{p, p + segment_length};
-      segments_.emplace(interval, Segment{it, it + 1, interval});
+      segments_.emplace(interval, Segment{idx, idx + 1, interval});
       p += segment_length;
     }
     length_ = p;

--- a/include/maliput_sparse/geometry/utility/geometry.h
+++ b/include/maliput_sparse/geometry/utility/geometry.h
@@ -38,17 +38,12 @@ namespace geometry {
 namespace utility {
 
 /// Holds the result of #GetBoundPointsAtP method.
-/// @tparam CoordinateT The coordinate type.
-template <typename CoordinateT>
 struct BoundPointsResult {
-  typename LineString<CoordinateT>::const_iterator first;
-  typename LineString<CoordinateT>::const_iterator second;
+  std::size_t idx_start;
+  std::size_t idx_end;
   // Length up to first.
   double length;
 };
-
-using BoundPointsResult3d = BoundPointsResult<maliput::math::Vector3>;
-using BoundPointsResult2d = BoundPointsResult<maliput::math::Vector2>;
 
 /// Holds the result of #GetClosestPoint method.
 /// @tparam CoordinateT The coordinate type.
@@ -101,8 +96,7 @@ double GetSlopeAtP(const LineString3d& line_string, double p, double tolerance);
 /// @param tolerance tolerance.
 /// @throws maliput::common::assertion_error When `p ∉ [0., line_string.length()]`.
 template <typename CoordinateT = maliput::math::Vector3>
-BoundPointsResult<CoordinateT> GetBoundPointsAtP(const LineString<CoordinateT>& line_string, double p,
-                                                 double tolerance);
+BoundPointsResult GetBoundPointsAtP(const LineString<CoordinateT>& line_string, double p, double tolerance);
 
 /// Returns the heading of a @p line_string for a given @p p .
 /// @param line_string LineString to be computed the heading from.

--- a/src/geometry/utility/geometry.cc
+++ b/src/geometry/utility/geometry.cc
@@ -328,11 +328,8 @@ double Get2DHeadingAtP(const LineString3d& line_string, double p, double toleran
 }
 
 Vector2 Get2DTangentAtP(const LineString3d& line_string, double p, double tolerance) {
-  // const double heading = Get2DHeadingAtP(line_string, p);
-  // return {std::cos(heading), std::sin(heading)};
-  const auto bound_points = GetBoundPointsAtP(line_string, p, tolerance);
-  const Vector2 d_xy{To2D(line_string[bound_points.idx_end]) - To2D(line_string[bound_points.idx_start])};
-  return (d_xy / (To2D(line_string).length())).normalized();
+  const double heading = Get2DHeadingAtP(line_string, p, tolerance);
+  return {std::cos(heading), std::sin(heading)};
 }
 
 Vector3 GetTangentAtP(const LineString3d& line_string, double p, double tolerance) {

--- a/src/geometry/utility/geometry.cc
+++ b/src/geometry/utility/geometry.cc
@@ -314,20 +314,9 @@ double GetSlopeAtP(const LineString3d& line_string, double p, double tolerance) 
 template <typename CoordinateT>
 BoundPointsResult<CoordinateT> GetBoundPointsAtP(const LineString<CoordinateT>& line_string, double p,
                                                  double tolerance) {
-  maliput::common::RangeValidator::GetAbsoluteEpsilonValidator(0., line_string.length(), tolerance, kEpsilon)(p);
-  BoundPointsResult<CoordinateT> result;
-  double current_cumulative_length = 0.0;
-  for (auto first = line_string.begin(), second = std::next(line_string.begin()); second != line_string.end();
-       ++first, ++second) {
-    const auto p1 = *first;
-    const auto p2 = *second;
-    const double current_length = (p1 - p2).norm();
-    if (current_cumulative_length + current_length >= p) {
-      return {first, second, current_cumulative_length};
-    }
-    current_cumulative_length += current_length;
-  }
-  return {line_string.end() - 1, line_string.end() - 2, line_string.length()};
+  p = maliput::common::RangeValidator::GetAbsoluteEpsilonValidator(0., line_string.length(), tolerance, kEpsilon)(p);
+  const auto segment = line_string.segments().at(typename LineString<CoordinateT>::Segment::Interval{p});
+  return {segment.start, segment.end, segment.p_interval.min};
 }
 
 double Get2DHeadingAtP(const LineString3d& line_string, double p, double tolerance) {

--- a/test/base/lane_test.cc
+++ b/test/base/lane_test.cc
@@ -95,12 +95,14 @@ std::vector<LaneTestCase> LaneTestCases() {
               {
                   {50., 0., 0.},
                   {50., -2., -2.},
+                  {100. + (102. * std::sqrt(2.) / 2.), 0., 0.},
                   {100. + 102. * std::sqrt(2.), 0., 0.},
                   {100. + 102. * std::sqrt(2.) + 98., -1., 4.},
               } /* srh */,
               {
                   {50., 0., 100.},
                   {50., -2., 98.},
+                  {151., 51., 100.},
                   {202., 102., 100.},
                   {203., 200., 104.},
               } /* expected_backend_pos */,
@@ -109,6 +111,7 @@ std::vector<LaneTestCase> LaneTestCases() {
                   Rotation::FromRpy(0., 0., 0.),
                   Rotation::FromRpy(0., 0., M_PI / 4.),
                   Rotation::FromRpy(0., 0., M_PI / 2.),
+                  Rotation::FromRpy(0., 0., M_PI / 2.),
               } /* expected_rotation */,
               100. + 102. * std::sqrt(2.) + 98. /* expected_length */,
               {{
@@ -116,6 +119,11 @@ std::vector<LaneTestCase> LaneTestCases() {
                },
                {
                    {50., -2., -2.} /* lane_position */, {50., -2., 98.} /* nearest_position */, 0. /* distance */
+               },
+               {
+                   {100. + (102. * std::sqrt(2.) / 2.), 0., 0.} /* lane_position */,
+                   {151., 51., 100.} /* nearest_position */,
+                   0. /* distance */
                },
                {
                    {100. + 102. * std::sqrt(2.), 0., 0.} /* lane_position */,

--- a/test/geometry/line_string_test.cc
+++ b/test/geometry/line_string_test.cc
@@ -54,6 +54,81 @@ struct SquaredDistanceFunction {
   double operator()(const VectorT& v1, const VectorT& v2) const { return std::pow((v1 - v2).norm(), 2.); }
 };
 
+class SegmentIntervalTest : public ::testing::Test {};
+
+TEST_F(SegmentIntervalTest, Constructors) {
+  EXPECT_NO_THROW((LineString3d::Segment::Interval{0., 1.}));
+  EXPECT_THROW((LineString3d::Segment::Interval{1., 0.}), maliput::common::assertion_error);
+}
+
+TEST_F(SegmentIntervalTest, ValuesUsing2ArgsConstructor) {
+  const LineString3d::Segment::Interval dut(0., 1.);
+  EXPECT_EQ(0., dut.min);
+  EXPECT_EQ(1., dut.max);
+}
+
+TEST_F(SegmentIntervalTest, ValuesUsing1ArgsConstructor) {
+  const LineString3d::Segment::Interval dut(10.);
+  EXPECT_EQ(10., dut.min);
+  EXPECT_EQ(10., dut.max);
+}
+
+TEST_F(SegmentIntervalTest, OperatorLessThan) {
+  const LineString3d::Segment::Interval dut(0., 10.);
+  // True because dut's min is less than the other's min.
+  EXPECT_TRUE(dut < LineString3d::Segment::Interval(5., 15.));
+  // False because dut's min is greater than the other's max.
+  EXPECT_FALSE(dut < LineString3d::Segment::Interval(-5., 0.));
+  // True because both p are greater than dut's.
+  EXPECT_TRUE(dut < LineString3d::Segment::Interval(15., 20.));
+  // False because the intervals are equal.
+  EXPECT_FALSE(dut < LineString3d::Segment::Interval(0., 10.));
+}
+
+TEST_F(SegmentIntervalTest, Map) {
+  std::map<LineString3d::Segment::Interval, int> map{
+      {LineString3d::Segment::Interval(0., 10.), 0},  {LineString3d::Segment::Interval(10., 20.), 1},
+      {LineString3d::Segment::Interval(20., 30.), 2}, {LineString3d::Segment::Interval(30., 40.), 3},
+      {LineString3d::Segment::Interval(40., 50.), 4}, {LineString3d::Segment::Interval(50., 60.), 5},
+      {LineString3d::Segment::Interval(60., 70.), 6}, {LineString3d::Segment::Interval(70., 80.), 7},
+      {LineString3d::Segment::Interval(80., 90.), 8}, {LineString3d::Segment::Interval(90., 100.), 9},
+  };
+  EXPECT_EQ(0, map.at(LineString3d::Segment::Interval(0.)));
+  EXPECT_EQ(0, map.at(LineString3d::Segment::Interval(5.)));
+  EXPECT_EQ(1, map.at(LineString3d::Segment::Interval(10.)));
+  EXPECT_EQ(1, map.at(LineString3d::Segment::Interval(15.)));
+  EXPECT_EQ(2, map.at(LineString3d::Segment::Interval(20.)));
+}
+
+class SegmentTest : public ::testing::Test {
+ public:
+  const std::vector<maliput::math::Vector3> points_3d_ = {
+      maliput::math::Vector3(0., 0., 0.),
+      maliput::math::Vector3(10., 0., 0.),
+      maliput::math::Vector3(20., 0., 0.),
+  };
+  LineString3d::Segment::Interval interval_1{0., 10.};
+  LineString3d::Segment::Interval interval_2{10., 20.};
+};
+
+TEST_F(SegmentTest, Constructor) {
+  EXPECT_NO_THROW((LineString3d::Segment{points_3d_.begin(), points_3d_.begin() + 1, interval_1}));
+}
+
+TEST_F(SegmentTest, Values) {
+  const LineString3d::Segment dut_1{points_3d_.begin(), points_3d_.begin() + 1, interval_1};
+  EXPECT_EQ(points_3d_.begin(), dut_1.start);
+  EXPECT_EQ(points_3d_.begin() + 1, dut_1.end);
+  EXPECT_EQ(interval_1.min, dut_1.p_interval.min);
+  EXPECT_EQ(interval_1.max, dut_1.p_interval.max);
+
+  const LineString3d::Segment dut_2{points_3d_.begin() + 1, points_3d_.end(), interval_2};
+  EXPECT_EQ(points_3d_.begin() + 1, dut_2.start);
+  EXPECT_EQ(points_3d_.end(), dut_2.end);
+  EXPECT_EQ(interval_2.min, dut_2.p_interval.min);
+  EXPECT_EQ(interval_2.max, dut_2.p_interval.max);
+}
+
 class LineString3dTest : public ::testing::Test {
  public:
   const Vector3 p1{Vector3::UnitX()};
@@ -83,6 +158,27 @@ TEST_F(LineString3dTest, Api) {
   EXPECT_TRUE(p3 == dut.at(2));
   EXPECT_EQ(static_cast<size_t>(3), dut.size());
   EXPECT_NEAR(2. * std::sqrt(2.), dut.length(), kTolerance);
+}
+
+TEST_F(LineString3dTest, Segments) {
+  const LineString3d dut(std::vector<Vector3>{p1, p2, p3});
+  const auto segments = dut.segments();
+  ASSERT_EQ(static_cast<size_t>(2), segments.size());
+
+  const double p_in_p1_p2 = (p1 - p2).norm() / 2.;
+  const double p_in_p2_p3 = (p1 - p2).norm() + (p2 - p3).norm() / 2.;
+
+  const auto segment_p1_p2 = segments.at(LineString3d::Segment::Interval(p_in_p1_p2));
+  EXPECT_TRUE(p1 == *segment_p1_p2.start);
+  EXPECT_TRUE(p2 == *segment_p1_p2.end);
+  EXPECT_NEAR(0., segment_p1_p2.p_interval.min, kTolerance);
+  EXPECT_NEAR((p1 - p2).norm(), segment_p1_p2.p_interval.max, kTolerance);
+
+  const auto segment_p2_p3 = segments.at(LineString3d::Segment::Interval(p_in_p2_p3));
+  EXPECT_TRUE(p2 == *segment_p2_p3.start);
+  EXPECT_TRUE(p3 == *segment_p2_p3.end);
+  EXPECT_NEAR((p1 - p2).norm(), segment_p2_p3.p_interval.min, kTolerance);
+  EXPECT_NEAR((p1 - p2).norm() + (p2 - p3).norm(), segment_p2_p3.p_interval.max, kTolerance);
 }
 
 TEST_F(LineString3dTest, LengthInjectedDistanceFunction) {

--- a/test/geometry/line_string_test.cc
+++ b/test/geometry/line_string_test.cc
@@ -111,20 +111,18 @@ class SegmentTest : public ::testing::Test {
   LineString3d::Segment::Interval interval_2{10., 20.};
 };
 
-TEST_F(SegmentTest, Constructor) {
-  EXPECT_NO_THROW((LineString3d::Segment{points_3d_.begin(), points_3d_.begin() + 1, interval_1}));
-}
+TEST_F(SegmentTest, Constructor) { EXPECT_NO_THROW((LineString3d::Segment{0, 1, interval_1})); }
 
 TEST_F(SegmentTest, Values) {
-  const LineString3d::Segment dut_1{points_3d_.begin(), points_3d_.begin() + 1, interval_1};
-  EXPECT_EQ(points_3d_.begin(), dut_1.start);
-  EXPECT_EQ(points_3d_.begin() + 1, dut_1.end);
+  const LineString3d::Segment dut_1{0, 1, interval_1};
+  EXPECT_EQ(static_cast<std::size_t>(0), dut_1.idx_start);
+  EXPECT_EQ(static_cast<std::size_t>(1), dut_1.idx_end);
   EXPECT_EQ(interval_1.min, dut_1.p_interval.min);
   EXPECT_EQ(interval_1.max, dut_1.p_interval.max);
 
-  const LineString3d::Segment dut_2{points_3d_.begin() + 1, points_3d_.end(), interval_2};
-  EXPECT_EQ(points_3d_.begin() + 1, dut_2.start);
-  EXPECT_EQ(points_3d_.end(), dut_2.end);
+  const LineString3d::Segment dut_2{1, 2, interval_2};
+  EXPECT_EQ(static_cast<std::size_t>(1), dut_2.idx_start);
+  EXPECT_EQ(static_cast<std::size_t>(2), dut_2.idx_end);
   EXPECT_EQ(interval_2.min, dut_2.p_interval.min);
   EXPECT_EQ(interval_2.max, dut_2.p_interval.max);
 }
@@ -169,14 +167,14 @@ TEST_F(LineString3dTest, Segments) {
   const double p_in_p2_p3 = (p1 - p2).norm() + (p2 - p3).norm() / 2.;
 
   const auto segment_p1_p2 = segments.at(LineString3d::Segment::Interval(p_in_p1_p2));
-  EXPECT_TRUE(p1 == *segment_p1_p2.start);
-  EXPECT_TRUE(p2 == *segment_p1_p2.end);
+  EXPECT_TRUE(p1 == dut[segment_p1_p2.idx_start]);
+  EXPECT_TRUE(p2 == dut[segment_p1_p2.idx_end]);
   EXPECT_NEAR(0., segment_p1_p2.p_interval.min, kTolerance);
   EXPECT_NEAR((p1 - p2).norm(), segment_p1_p2.p_interval.max, kTolerance);
 
   const auto segment_p2_p3 = segments.at(LineString3d::Segment::Interval(p_in_p2_p3));
-  EXPECT_TRUE(p2 == *segment_p2_p3.start);
-  EXPECT_TRUE(p3 == *segment_p2_p3.end);
+  EXPECT_TRUE(p2 == dut[segment_p2_p3.idx_start]);
+  EXPECT_TRUE(p3 == dut[segment_p2_p3.idx_end]);
   EXPECT_NEAR((p1 - p2).norm(), segment_p2_p3.p_interval.min, kTolerance);
   EXPECT_NEAR((p1 - p2).norm() + (p2 - p3).norm(), segment_p2_p3.p_interval.max, kTolerance);
 }

--- a/test/geometry/utility/geometry_test.cc
+++ b/test/geometry/utility/geometry_test.cc
@@ -242,34 +242,34 @@ class GetBoundPointsAtPTest : public ::testing::Test {
 TEST_F(GetBoundPointsAtPTest, Test) {
   {
     const double p{0.};
-    const BoundPointsResult3d expected_result{line_string.begin(), line_string.begin() + 1, 0.};
-    const BoundPointsResult3d dut = GetBoundPointsAtP(line_string, p, kTolerance);
-    EXPECT_EQ(expected_result.first, dut.first);
-    EXPECT_EQ(expected_result.second, dut.second);
+    const BoundPointsResult expected_result{0, 1, 0.};
+    const BoundPointsResult dut = GetBoundPointsAtP(line_string, p, kTolerance);
+    EXPECT_EQ(expected_result.idx_start, dut.idx_start);
+    EXPECT_EQ(expected_result.idx_end, dut.idx_end);
     EXPECT_EQ(expected_result.length, dut.length);
   }
   {
     const double p{7.5};
-    const BoundPointsResult3d expected_result{line_string.begin() + 1, line_string.begin() + 2, 7.};
-    const BoundPointsResult3d dut = GetBoundPointsAtP(line_string, p, kTolerance);
-    EXPECT_EQ(expected_result.first, dut.first);
-    EXPECT_EQ(expected_result.second, dut.second);
+    const BoundPointsResult expected_result{1, 2, 7.};
+    const BoundPointsResult dut = GetBoundPointsAtP(line_string, p, kTolerance);
+    EXPECT_EQ(expected_result.idx_start, dut.idx_start);
+    EXPECT_EQ(expected_result.idx_end, dut.idx_end);
     EXPECT_EQ(expected_result.length, dut.length);
   }
   {
     const double p{12.5};
-    const BoundPointsResult3d expected_result{line_string.begin() + 2, line_string.begin() + 3, 12.};
-    const BoundPointsResult3d dut = GetBoundPointsAtP(line_string, p, kTolerance);
-    EXPECT_EQ(expected_result.first, dut.first);
-    EXPECT_EQ(expected_result.second, dut.second);
+    const BoundPointsResult expected_result{2, 3, 12.};
+    const BoundPointsResult dut = GetBoundPointsAtP(line_string, p, kTolerance);
+    EXPECT_EQ(expected_result.idx_start, dut.idx_start);
+    EXPECT_EQ(expected_result.idx_end, dut.idx_end);
     EXPECT_EQ(expected_result.length, dut.length);
   }
   {
     const double p{19.5};
-    const BoundPointsResult3d expected_result{line_string.begin() + 3, line_string.begin() + 4, 19.};
-    const BoundPointsResult3d dut = GetBoundPointsAtP(line_string, p, kTolerance);
-    EXPECT_EQ(expected_result.first, dut.first);
-    EXPECT_EQ(expected_result.second, dut.second);
+    const BoundPointsResult expected_result{3, 4, 19.};
+    const BoundPointsResult dut = GetBoundPointsAtP(line_string, p, kTolerance);
+    EXPECT_EQ(expected_result.idx_start, dut.idx_start);
+    EXPECT_EQ(expected_result.idx_end, dut.idx_end);
     EXPECT_EQ(expected_result.length, dut.length);
   }
 }
@@ -291,19 +291,19 @@ std::vector<SlopeTestCase> SlopeTestCases() {
       {
           // LineString with different z values along y axis.
           LineString3d{{0., 0., 0.}, {5., 0., 5.}, {10., 0., 5.}, {15., 0., 10.}} /* line string*/,
-          {0., std::sqrt(2.) * 5, std::sqrt(2.) * 5 + 5., 2 * std::sqrt(2.) * 5 + 5.} /* ps */,
+          {0., std::sqrt(2.) * 5. / 2., std::sqrt(2.) * 5. + 5. / 2., 2 * std::sqrt(2.) * 5. + 5.} /* ps */,
           {1., 1., 0., 1.} /* expected_slopes */
       },
       {
           // LineString with different z values along x axis.
           LineString3d{{0., 0., 0.}, {0., 5., 5.}, {0., 10., 5.}, {0., 15., 10.}} /* line string*/,
-          {0., std::sqrt(2.) * 5, std::sqrt(2.) * 5 + 5., 2 * std::sqrt(2.) * 5 + 5.} /* ps */,
+          {0., std::sqrt(2.) * 5. / 2., std::sqrt(2.) * 5. + 5. / 2., 2 * std::sqrt(2.) * 5. + 5.} /* ps */,
           {1., 1., 0., 1.} /* expected_slopes */
       },
       {
           // LineString with different z values.
           LineString3d{{0., 0., 0.}, {6., 3., 2.}, {10., 6., 2.}, {16., 9., 4.}, {10., 6., 2.}} /* line string*/,
-          {0., 7., 12., 19., 26.} /* ps */,
+          {0., 3.5, 10.5, 17., 26.} /* ps */,
           {2. / std::sqrt(45), 2. / std::sqrt(45), 0., 2. / std::sqrt(45), -2. / std::sqrt(45)} /* expected_slopes */
       },
   };


### PR DESCRIPTION
# 🎉 New feature

Related to #50 #47 

## Summary

TODO

### Speed up
|              Benchmark name              | cpu time[us] |            cpu time[us]           | speed up |        map       |
|:----------------------------------------:|:------------:|:---------------------------------:|:--------:|:----------------:|
|                                          |     main     | francocipollone/segments_interval |          |                  |
| MaliputOsmQueryTime/GetLane/0            |        0.025 |                             0.022 |     1.14 | SingleLane.osm   |
| MaliputOsmQueryTime/GetLane/1            |        0.023 |                             0.023 |     1.00 | ArcLane.osm      |
| MaliputOsmQueryTime/GetLane/2            |        0.024 |                             0.025 |     0.96 | ArcLaneDense.osm |
| MaliputOsmQueryTime/GetLane/3            |        0.024 |                             0.022 |     1.09 | Circuit.osm      |
| MaliputOsmQueryTime/Length/0             |        0.003 |                             0.003 |     1.00 | SingleLane.osm   |
| MaliputOsmQueryTime/Length/1             |        0.003 |                             0.003 |     1.00 | ArcLane.osm      |
| MaliputOsmQueryTime/Length/2             |        0.003 |                             0.003 |     1.00 | ArcLaneDense.osm |
| MaliputOsmQueryTime/Length/3             |        0.003 |                             0.003 |     1.00 | Circuit.osm      |
| MaliputOsmQueryTime/ToLanePosition/0     |         5.22 |                              3.15 |     1.66 | SingleLane.osm   |
| MaliputOsmQueryTime/ToLanePosition/1     |           36 |                              17.8 |     2.02 | ArcLane.osm      |
| MaliputOsmQueryTime/ToLanePosition/2     |         1447 |                               568 |     2.55 | ArcLaneDense.osm |
| MaliputOsmQueryTime/ToLanePosition/3     |          107 |                              35.8 |     2.99 | Circuit.osm      |
| MaliputOsmQueryTime/ToInertialPosition/0 |         1.68 |                              1.09 |     1.54 | SingleLane.osm   |
| MaliputOsmQueryTime/ToInertialPosition/1 |         10.2 |                              4.05 |     2.52 | ArcLane.osm      |
| MaliputOsmQueryTime/ToInertialPosition/2 |          318 |                               117 |     2.72 | ArcLaneDense.osm |
| MaliputOsmQueryTime/ToInertialPosition/3 |         20.9 |                              8.09 |     2.58 | Circuit.osm      |
| MaliputOsmQueryTime/GetOrientation/0     |         1.52 |                             0.935 |     1.63 | SingleLane.osm   |
| MaliputOsmQueryTime/GetOrientation/1     |         8.81 |                              4.07 |     2.16 | ArcLane.osm      |
| MaliputOsmQueryTime/GetOrientation/2     |          341 |                               126 |     2.71 | ArcLaneDense.osm |
| MaliputOsmQueryTime/GetOrientation/3     |         20.3 |                              7.68 |     2.64 | Circuit.osm      |
| MaliputOsmQueryTime/ToRoadPosition/0     |         12.5 |                              8.64 |     1.45 | SingleLane.osm   |
| MaliputOsmQueryTime/ToRoadPosition/1     |         94.1 |                                42 |     2.24 | ArcLane.osm      |
| MaliputOsmQueryTime/ToRoadPosition/2     |         3532 |                              1354 |     2.61 | ArcLaneDense.osm |
| MaliputOsmQueryTime/ToRoadPosition/3     |         1836 |                               665 |     2.76 | Circuit.osm      |
| MaliputOsmQueryTime/FindRoadPositions/0  |         10.1 |                              7.53 |     1.34 | SingleLane.osm   |
| MaliputOsmQueryTime/FindRoadPositions/1  |           82 |                              34.9 |     2.35 | ArcLane.osm      |
| MaliputOsmQueryTime/FindRoadPositions/2  |         2897 |                              1224 |     2.37 | ArcLaneDense.osm |
| MaliputOsmQueryTime/FindRoadPositions/3  |         1753 |                               577 |     3.04 | Circuit.osm      |


## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
