### PR TITLE
Some fixes for clang build and sanitizers check

### DIFF
--- a/.github/try_vcs_checkout
+++ b/.github/try_vcs_checkout
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Copyright 2023 Woven By Toyota
+
+CHANGE_BRANCH=$1
+SRC_FOLDER=$2
+
+echo try checking out ${CHANGE_BRANCH}
+vcs custom $SRC_FOLDER --args branch -f $CHANGE_BRANCH origin/$CHANGE_BRANCH > /dev/null || true
+vcs custom $SRC_FOLDER --args merge --no-edit $CHANGE_BRANCH  > /dev/null || true
+DIFF=$(vcs diff -s $SRC_FOLDER | tr -d '.\n')
+if [ ! -z "$DIFF" ]; then
+    echo "Have merge conflicts!"
+    echo $DIFF
+    exit 1
+fi
+vcs status $SRC_FOLDER

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: gcc
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -10,6 +12,11 @@ on:
 env:
   PACKAGE_NAME: maliput_sparse
   ROS_DISTRO: foxy
+
+# Cancel previously running PR jobs
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
 
 jobs:
   compile_and_test:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   compile_and_test:
-    if: contains(github.event.pull_request.labels.*.name, 'do-clang-test')
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'do-clang-test') || github.event_name == 'workflow_dispatch'}}
     name: Compile and test with sanitizer
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/scan_build.yml
+++ b/.github/workflows/scan_build.yml
@@ -47,7 +47,7 @@ jobs:
       shell: bash
       working-directory: ${{ env.ROS_WS }}
       run: |
-        rosdep update
+        rosdep update --include-eol-distros
         rosdep install  -i -y --rosdistro ${ROS_DISTRO} --skip-keys "pybind11" --from-paths src
     - name: colcon build up-to
       shell: bash

--- a/.github/workflows/scan_build.yml
+++ b/.github/workflows/scan_build.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   static_analysis:
-    if: contains(github.event.pull_request.labels.*.name, 'do-static-analyzer-test')
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'do-static-analyzer-test') || github.event_name == 'workflow_dispatch'}}
     name: Static analysis
     runs-on: ubuntu-latest
     container:

--- a/src/geometry/utility/geometry.cc
+++ b/src/geometry/utility/geometry.cc
@@ -452,6 +452,8 @@ template ClosestPointToSegmentResult2d GetClosestPointToSegment(const maliput::m
 template class ClosestPointResult<maliput::math::Vector3>;
 template class ClosestPointResult<maliput::math::Vector2>;
 
+template BoundPointsResult GetBoundPointsAtP<maliput::math::Vector3>(const LineString3d&, double, double);
+
 }  // namespace utility
 }  // namespace geometry
 }  // namespace maliput_sparse

--- a/src/geometry/utility/geometry.cc
+++ b/src/geometry/utility/geometry.cc
@@ -300,7 +300,10 @@ double GetSlopeAtP(const LineString3d& line_string, double p, double tolerance) 
   const double delta_z{end.z() - start.z()};
   const double dist{(To2D(end) - To2D(start)).norm()};
   MALIPUT_THROW_UNLESS(start != end);
-  return delta_z / dist;
+  return dist < std::numeric_limits<double>::epsilon()
+             ? (std::signbit(delta_z) ? -std::numeric_limits<double>::infinity()
+                                      : std::numeric_limits<double>::infinity())
+             : delta_z / dist;
 }
 
 template <typename CoordinateT>
@@ -449,8 +452,8 @@ template ClosestPointToSegmentResult2d GetClosestPointToSegment(const maliput::m
                                                                 const maliput::math::Vector2&,
                                                                 const maliput::math::Vector2&, double);
 
-template class ClosestPointResult<maliput::math::Vector3>;
-template class ClosestPointResult<maliput::math::Vector2>;
+template struct ClosestPointResult<maliput::math::Vector3>;
+template struct ClosestPointResult<maliput::math::Vector2>;
 
 template BoundPointsResult GetBoundPointsAtP<maliput::math::Vector3>(const LineString3d&, double, double);
 


### PR DESCRIPTION
# 🦟 Bug fix

Related to https://github.com/maliput/maliput_infrastructure/pull/312

## Summary
- There was a missing template instantiation that was raised by clang compiler. 
```cpp
template <typename CoordinateT = maliput::math::Vector3>
BoundPointsResult GetBoundPointsAtP(const LineString<CoordinateT>& line_string, double p, double tolerance);
```
For gcc it seems that the compiler uses the default for creating an implicit instantiation whereas clang does not.

 - The `ubsan` sanitizer was complaining about division by zero: Fixed.
 - Some minor improvements to clang and scan build workflows were added.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
