### PR TITLE
Uses compare methods instead of maliput test utilities.

### DIFF
--- a/src/test_utilities/CMakeLists.txt
+++ b/src/test_utilities/CMakeLists.txt
@@ -23,7 +23,6 @@ target_include_directories(
 
 target_link_libraries(test_utilities
    PRIVATE
-    maliput::test_utilities
     maliput_sparse::geometry
 )
 

--- a/test/assert_compare.h
+++ b/test/assert_compare.h
@@ -1,7 +1,6 @@
 // BSD 3-Clause License
 //
-// Copyright (c) 2022, Woven Planet.
-// All rights reserved.
+// Copyright (c) 2023, Woven by Toyota. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -27,25 +26,20 @@
 // CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#include "maliput_sparse/test_utilties/maliput_sparse_types_compare.h"
+#pragma once
 
-#include <maliput/math/compare.h>
+#include <gtest/gtest.h>
+#include <maliput/common/compare.h>
 
 namespace maliput_sparse {
 namespace test {
 
-::testing::AssertionResult CompareLineString3d(const maliput_sparse::geometry::LineString3d& lhs,
-                                               const maliput_sparse::geometry::LineString3d& rhs, double tolerance) {
-  if (lhs.size() != rhs.size()) {
-    return ::testing::AssertionFailure() << "LineString3d size mismatch: " << lhs.size() << " != " << rhs.size();
+template <typename T>
+::testing::AssertionResult AssertCompare(const maliput::common::ComparisonResult<T>& res) {
+  if (!res.message.has_value()) {
+    return ::testing::AssertionSuccess();
   }
-  for (size_t i = 0; i < lhs.size(); ++i) {
-    if (maliput::math::CompareVectors(lhs[i], rhs[i], tolerance).message.has_value()) {
-      return ::testing::AssertionFailure()
-             << "LineString3d point mismatch at index " << i << ": " << lhs[i] << " != " << rhs[i];
-    }
-  }
-  return ::testing::AssertionSuccess();
+  return ::testing::AssertionFailure() << res.message.value();
 }
 
 }  // namespace test

--- a/test/base/CMakeLists.txt
+++ b/test/base/CMakeLists.txt
@@ -17,7 +17,6 @@ if (TARGET ${target})
           maliput::common
           maliput::geometry_base
           maliput::math
-          maliput::test_utilities
           maliput_sparse::base
           maliput_sparse::builder
           maliput_sparse::geometry

--- a/test/base/lane_test.cc
+++ b/test/base/lane_test.cc
@@ -30,14 +30,15 @@
 #include "base/lane.h"
 
 #include <gtest/gtest.h>
+#include <maliput/api/compare.h>
 #include <maliput/api/lane.h>
 #include <maliput/api/lane_data.h>
 #include <maliput/common/assertion_error.h>
 #include <maliput/geometry_base/segment.h>
+#include <maliput/math/compare.h>
 #include <maliput/math/vector.h>
-#include <maliput/test_utilities/maliput_math_compare.h>
-#include <maliput/test_utilities/maliput_types_compare.h>
 
+#include "assert_compare.h"
 #include "maliput_sparse/geometry/line_string.h"
 
 namespace maliput_sparse {
@@ -46,16 +47,16 @@ namespace {
 
 using geometry::LineString3d;
 using maliput::api::InertialPosition;
+using maliput::api::IsInertialPositionClose;
+using maliput::api::IsLanePositionClose;
+using maliput::api::IsLanePositionResultClose;
 using maliput::api::IsoLaneVelocity;
+using maliput::api::IsRotationClose;
 using maliput::api::LaneId;
 using maliput::api::LanePosition;
 using maliput::api::LanePositionResult;
 using maliput::api::RBounds;
 using maliput::api::Rotation;
-using maliput::api::test::IsInertialPositionClose;
-using maliput::api::test::IsLanePositionClose;
-using maliput::api::test::IsLanePositionResultClose;
-using maliput::api::test::IsRotationClose;
 using maliput::math::Vector2;
 using maliput::math::Vector3;
 
@@ -231,10 +232,11 @@ TEST_P(LaneTest, Test) {
     const auto backend_pos = dut->ToBackendPosition(case_.srh[i]);
     const auto rpy = dut->GetOrientation(case_.srh[i]);
     const auto lane_position_result = dut->ToLanePositionBackend(case_.expected_backend_pos[i]);
-    EXPECT_TRUE(IsRotationClose(case_.expected_rotation[i], rpy, kTolerance));
-    EXPECT_TRUE(
-        IsInertialPositionClose(case_.expected_backend_pos[i], InertialPosition::FromXyz(backend_pos), kTolerance));
-    EXPECT_TRUE(IsLanePositionResultClose(case_.expected_lane_position_result[i], lane_position_result, kTolerance));
+    EXPECT_TRUE(AssertCompare(IsRotationClose(case_.expected_rotation[i], rpy, kTolerance)));
+    EXPECT_TRUE(AssertCompare(
+        IsInertialPositionClose(case_.expected_backend_pos[i], InertialPosition::FromXyz(backend_pos), kTolerance)));
+    EXPECT_TRUE(AssertCompare(
+        IsLanePositionResultClose(case_.expected_lane_position_result[i], lane_position_result, kTolerance)));
   }
 }
 
@@ -402,10 +404,11 @@ TEST_P(ToLaneSegmentPositionTest, Test) {
   EXPECT_DOUBLE_EQ(case_.segment_bounds.max(), seg_bounds.max());
   for (std::size_t i = 0; i < case_.backend_pos.size(); ++i) {
     const LanePositionResult lane_position_result = dut_->ToLanePositionBackend(case_.backend_pos[i]);
-    EXPECT_TRUE(IsLanePositionResultClose(case_.expected_lane_position_result[i], lane_position_result, kTolerance));
+    EXPECT_TRUE(AssertCompare(
+        IsLanePositionResultClose(case_.expected_lane_position_result[i], lane_position_result, kTolerance)));
     const LanePositionResult segment_position_result = dut_->ToSegmentPositionBackend(case_.backend_pos[i]);
-    EXPECT_TRUE(
-        IsLanePositionResultClose(case_.expected_segment_lane_position_result[i], segment_position_result, kTolerance));
+    EXPECT_TRUE(AssertCompare(IsLanePositionResultClose(case_.expected_segment_lane_position_result[i],
+                                                        segment_position_result, kTolerance)));
   }
 }
 

--- a/test/base/road_geometry_test.cc
+++ b/test/base/road_geometry_test.cc
@@ -32,12 +32,13 @@
 #include <string>
 
 #include <gtest/gtest.h>
+#include <maliput/api/compare.h>
 #include <maliput/api/lane.h>
 #include <maliput/api/lane_data.h>
 #include <maliput/api/road_geometry.h>
 #include <maliput/math/vector.h>
-#include <maliput/test_utilities/maliput_types_compare.h>
 
+#include "assert_compare.h"
 #include "maliput_sparse/builder/builder.h"
 #include "maliput_sparse/geometry/line_string.h"
 
@@ -116,8 +117,8 @@ TEST_F(RoadGeometryTest, OnLaneA) {
       {5., 8., 0.}, /* nearest position */
       0.,           /* distance */
   };
-  EXPECT_TRUE(maliput::api::test::IsRoadPositionResultClose(expected_road_position_result,
-                                                            dut_->ToRoadPosition(inertial_pos), kLinearTolerance));
+  EXPECT_TRUE(AssertCompare(maliput::api::IsRoadPositionResultClose(
+      expected_road_position_result, dut_->ToRoadPosition(inertial_pos), kLinearTolerance)));
 }
 
 TEST_F(RoadGeometryTest, OnLaneB) {
@@ -129,8 +130,8 @@ TEST_F(RoadGeometryTest, OnLaneB) {
       {5., 0., 0.}, /* nearest position */
       0.,           /* distance */
   };
-  EXPECT_TRUE(maliput::api::test::IsRoadPositionResultClose(expected_road_position_result,
-                                                            dut_->ToRoadPosition(inertial_pos), kLinearTolerance));
+  EXPECT_TRUE(AssertCompare(maliput::api::IsRoadPositionResultClose(
+      expected_road_position_result, dut_->ToRoadPosition(inertial_pos), kLinearTolerance)));
 }
 
 TEST_F(RoadGeometryTest, CloseToLaneA) {
@@ -142,8 +143,8 @@ TEST_F(RoadGeometryTest, CloseToLaneA) {
       {5., 10., 0.}, /* nearest position */
       1.,            /* distance */
   };
-  EXPECT_TRUE(maliput::api::test::IsRoadPositionResultClose(expected_road_position_result,
-                                                            dut_->ToRoadPosition(inertial_pos), kLinearTolerance));
+  EXPECT_TRUE(AssertCompare(maliput::api::IsRoadPositionResultClose(
+      expected_road_position_result, dut_->ToRoadPosition(inertial_pos), kLinearTolerance)));
 }
 
 }  // namespace

--- a/test/builder/CMakeLists.txt
+++ b/test/builder/CMakeLists.txt
@@ -15,7 +15,6 @@ if (TARGET ${target})
           maliput::common
           maliput::geometry_base
           maliput::math
-          maliput::test_utilities
           maliput_sparse::base
           maliput_sparse::builder
           maliput_sparse::geometry

--- a/test/builder/builder_test.cc
+++ b/test/builder/builder_test.cc
@@ -35,6 +35,7 @@
 #include <vector>
 
 #include <gtest/gtest.h>
+#include <maliput/api/compare.h>
 #include <maliput/api/junction.h>
 #include <maliput/api/lane.h>
 #include <maliput/api/lane_data.h>
@@ -42,8 +43,8 @@
 #include <maliput/api/segment.h>
 #include <maliput/common/assertion_error.h>
 #include <maliput/math/vector.h>
-#include <maliput/test_utilities/maliput_types_compare.h>
 
+#include "assert_compare.h"
 #include "maliput_sparse/geometry/lane_geometry.h"
 #include "maliput_sparse/geometry/line_string.h"
 #include "maliput_sparse/geometry/utility/geometry.h"
@@ -52,10 +53,11 @@ namespace maliput_sparse {
 namespace builder {
 namespace test {
 namespace {
-using maliput::api::test::IsHBoundsClose;
-using maliput::api::test::IsLaneEndEqual;
+using maliput::api::IsHBoundsClose;
+using maliput::api::IsLaneEndEqual;
 using maliput::math::Vector3;
 using maliput_sparse::geometry::LineString3d;
+using maliput_sparse::test::AssertCompare;
 
 class LaneEndTest : public ::testing::Test {
  protected:
@@ -396,12 +398,12 @@ TEST_F(RoadGeometryBuilderTest, CompleteCase) {
   auto* lane_a = segment_a->lane(0);
   ASSERT_NE(nullptr, lane_a);
   ASSERT_EQ(kLaneAId, lane_a->id());
-  ASSERT_TRUE(IsHBoundsClose(kHBoundsA, lane_a->elevation_bounds(0., 0.), kEqualityTolerance));
+  ASSERT_TRUE(AssertCompare(IsHBoundsClose(kHBoundsA, lane_a->elevation_bounds(0., 0.), kEqualityTolerance)));
 
   auto* lane_b = segment_a->lane(1);
   ASSERT_NE(nullptr, lane_b);
   ASSERT_EQ(kLaneBId, lane_b->id());
-  ASSERT_TRUE(IsHBoundsClose(kHBoundsB, lane_b->elevation_bounds(0., 0.), kEqualityTolerance));
+  ASSERT_TRUE(AssertCompare(IsHBoundsClose(kHBoundsB, lane_b->elevation_bounds(0., 0.), kEqualityTolerance)));
 
   ASSERT_EQ(lane_a, lane_b->to_right());
   ASSERT_EQ(lane_b, lane_a->to_left());
@@ -414,7 +416,7 @@ TEST_F(RoadGeometryBuilderTest, CompleteCase) {
   auto* lane_c = segment_b->lane(0);
   ASSERT_NE(nullptr, lane_c);
   ASSERT_EQ(kLaneCId, lane_c->id());
-  ASSERT_TRUE(IsHBoundsClose(kHBoundsC, lane_c->elevation_bounds(0., 0.), kEqualityTolerance));
+  ASSERT_TRUE(AssertCompare(IsHBoundsClose(kHBoundsC, lane_c->elevation_bounds(0., 0.), kEqualityTolerance)));
 
   auto* junction_b = rg->junction(1);
   ASSERT_NE(nullptr, junction_b);
@@ -429,7 +431,7 @@ TEST_F(RoadGeometryBuilderTest, CompleteCase) {
   auto* lane_d = segment_c->lane(0);
   ASSERT_NE(nullptr, lane_d);
   ASSERT_EQ(kLaneDId, lane_d->id());
-  ASSERT_TRUE(IsHBoundsClose(kHBoundsD, lane_d->elevation_bounds(0., 0.), kEqualityTolerance));
+  ASSERT_TRUE(AssertCompare(IsHBoundsClose(kHBoundsD, lane_d->elevation_bounds(0., 0.), kEqualityTolerance)));
 
   ASSERT_EQ(8, rg->num_branch_points());
   // Configure the BranchPoint check struct.
@@ -619,7 +621,7 @@ TEST_F(RoadGeometryBuilderTest, OutgoingBranches) {
   ASSERT_TRUE(lane_end_is_in(lane_b->GetConfluentBranches(start)->get(1), expected_lane_ends));
   ASSERT_TRUE(lane_end_is_in(lane_b->GetConfluentBranches(start)->get(2), expected_lane_ends));
   ASSERT_EQ(1, lane_b->GetOngoingBranches(start)->size());
-  ASSERT_TRUE(IsLaneEndEqual(lane_end_a_finish, lane_b->GetOngoingBranches(start)->get(0)));
+  ASSERT_TRUE(AssertCompare(IsLaneEndEqual(lane_end_a_finish, lane_b->GetOngoingBranches(start)->get(0))));
   ASSERT_EQ(1, lane_b->GetConfluentBranches(finish)->size());
   ASSERT_EQ(0, lane_b->GetOngoingBranches(finish)->size());
 
@@ -628,7 +630,7 @@ TEST_F(RoadGeometryBuilderTest, OutgoingBranches) {
   ASSERT_TRUE(lane_end_is_in(lane_c->GetConfluentBranches(start)->get(1), expected_lane_ends));
   ASSERT_TRUE(lane_end_is_in(lane_c->GetConfluentBranches(start)->get(2), expected_lane_ends));
   ASSERT_EQ(1, lane_c->GetOngoingBranches(start)->size());
-  ASSERT_TRUE(IsLaneEndEqual(lane_end_a_finish, lane_c->GetOngoingBranches(start)->get(0)));
+  ASSERT_TRUE(AssertCompare(IsLaneEndEqual(lane_end_a_finish, lane_c->GetOngoingBranches(start)->get(0))));
   ASSERT_EQ(1, lane_c->GetConfluentBranches(finish)->size());
   ASSERT_EQ(0, lane_c->GetOngoingBranches(finish)->size());
 
@@ -637,7 +639,7 @@ TEST_F(RoadGeometryBuilderTest, OutgoingBranches) {
   ASSERT_TRUE(lane_end_is_in(lane_d->GetConfluentBranches(start)->get(1), expected_lane_ends));
   ASSERT_TRUE(lane_end_is_in(lane_d->GetConfluentBranches(start)->get(2), expected_lane_ends));
   ASSERT_EQ(1, lane_d->GetOngoingBranches(start)->size());
-  ASSERT_TRUE(IsLaneEndEqual(lane_end_a_finish, lane_d->GetOngoingBranches(start)->get(0)));
+  ASSERT_TRUE(AssertCompare(IsLaneEndEqual(lane_end_a_finish, lane_d->GetOngoingBranches(start)->get(0))));
   ASSERT_EQ(1, lane_d->GetConfluentBranches(finish)->size());
   ASSERT_EQ(0, lane_d->GetOngoingBranches(finish)->size());
 }

--- a/test/geometry/CMakeLists.txt
+++ b/test/geometry/CMakeLists.txt
@@ -15,7 +15,6 @@ if (TARGET ${target})
       target_link_libraries(${target}
           maliput::common
           maliput::math
-          maliput::test_utilities
           maliput_sparse::geometry
       )
 

--- a/test/geometry/lane_geometry_test.cc
+++ b/test/geometry/lane_geometry_test.cc
@@ -31,16 +31,20 @@
 
 #include <gtest/gtest.h>
 #include <maliput/common/assertion_error.h>
+#include <maliput/math/compare.h>
 #include <maliput/math/vector.h>
-#include <maliput/test_utilities/maliput_math_compare.h>
+
+#include "assert_compare.h"
 
 namespace maliput_sparse {
 namespace geometry {
 namespace test {
 namespace {
 
+using maliput::math::CompareVectors;
 using maliput::math::Vector2;
 using maliput::math::Vector3;
+using maliput_sparse::test::AssertCompare;
 
 class LaneGeometryBasicTest : public testing::Test {
  public:
@@ -152,7 +156,7 @@ class OrientationTest : public ::testing::TestWithParam<OrientationTestCase> {
             : LaneGeometry{case_.left, case_.right, kLinearTolerance, kScaleLength};
     for (std::size_t i = 0; i < case_.p.size(); ++i) {
       const auto rpy = lane_geometry.Orientation(case_.p[i]);
-      EXPECT_TRUE(maliput::math::test::CompareVectors(case_.expected_rpy[i].vector(), rpy.vector(), GetTolerance()));
+      EXPECT_TRUE(AssertCompare(CompareVectors(case_.expected_rpy[i].vector(), rpy.vector(), GetTolerance())));
     }
   }
 };
@@ -265,9 +269,9 @@ TEST_P(WAndWInverseTest, Test) {
   const LaneGeometry lane_geometry{case_.left, case_.right, 1e-3, 1.};
   for (std::size_t i = 0; i < case_.prh.size(); ++i) {
     const auto dut_w = lane_geometry.W(case_.prh[i]);
-    EXPECT_TRUE(maliput::math::test::CompareVectors(case_.expected_w[i], dut_w, kTolerance));
+    EXPECT_TRUE(AssertCompare(CompareVectors(case_.expected_w[i], dut_w, kTolerance)));
     const auto dut_w_inverse = lane_geometry.WInverse(case_.expected_w[i]);
-    EXPECT_TRUE(maliput::math::test::CompareVectors(case_.prh[i], dut_w_inverse, kTolerance));
+    EXPECT_TRUE(AssertCompare(CompareVectors(case_.prh[i], dut_w_inverse, kTolerance)));
   }
 }
 
@@ -335,7 +339,7 @@ TEST_P(WDotTest, Test) {
   const LaneGeometry lane_geometry{case_.left, case_.right, 1e-3, 1.};
   for (std::size_t i = 0; i < case_.prh.size(); ++i) {
     const auto dut = lane_geometry.WDot(case_.prh[i]);
-    EXPECT_TRUE(maliput::math::test::CompareVectors(case_.expected_w_dot[i], dut, kTolerance));
+    EXPECT_TRUE(AssertCompare(CompareVectors(case_.expected_w_dot[i], dut, kTolerance)));
   }
 }
 

--- a/test/geometry/utility/geometry_test.cc
+++ b/test/geometry/utility/geometry_test.cc
@@ -35,8 +35,10 @@
 
 #include <gtest/gtest.h>
 #include <maliput/common/assertion_error.h>
+#include <maliput/math/compare.h>
 #include <maliput/math/vector.h>
-#include <maliput/test_utilities/maliput_math_compare.h>
+
+#include "assert_compare.h"
 
 namespace maliput_sparse {
 namespace geometry {
@@ -44,7 +46,9 @@ namespace utility {
 namespace test {
 namespace {
 
+using maliput::math::CompareVectors;
 using maliput::math::Vector3;
+using maliput_sparse::test::AssertCompare;
 
 struct LeftRightCenterlineCase {
   LineString3d left{};
@@ -215,7 +219,7 @@ class InterpolatedPointAtPTest : public ::testing::TestWithParam<LineStringPoint
 TEST_P(InterpolatedPointAtPTest, Test) {
   const auto dut =
       InterpolatedPointAtP(line_string_point_at_p_case_.line_string, line_string_point_at_p_case_.p, kTolerance);
-  EXPECT_TRUE(maliput::math::test::CompareVectors(line_string_point_at_p_case_.expected_point, dut, kTolerance));
+  EXPECT_TRUE(AssertCompare(CompareVectors(line_string_point_at_p_case_.expected_point, dut, kTolerance)));
 }
 
 TEST_P(InterpolatedPointAtPTest, NegativeP) {
@@ -442,7 +446,7 @@ TEST_P(GetClosestPointToSegmentTest, Test) {
     const auto dut =
         GetClosestPointToSegment(case_.segment.first, case_.segment.second, case_.eval_points[i], kTolerance);
     EXPECT_NEAR(case_.expected_closest[i].p, dut.p, kTolerance);
-    EXPECT_TRUE(maliput::math::test::CompareVectors(case_.expected_closest[i].point, dut.point, kTolerance));
+    EXPECT_TRUE(AssertCompare(CompareVectors(case_.expected_closest[i].point, dut.point, kTolerance)));
     EXPECT_NEAR(case_.expected_closest[i].distance, dut.distance, kTolerance);
   }
 }
@@ -500,7 +504,7 @@ TEST_P(GetClosestPointLineStringTest, Test) {
   for (std::size_t i = 0; i < case_.eval_points.size(); ++i) {
     const auto dut = GetClosestPoint(case_.line_string, case_.eval_points[i], kTolerance);
     EXPECT_NEAR(case_.expected_closest[i].p, dut.p, kTolerance);
-    EXPECT_TRUE(maliput::math::test::CompareVectors(case_.expected_closest[i].point, dut.point, kTolerance));
+    EXPECT_TRUE(AssertCompare(CompareVectors(case_.expected_closest[i].point, dut.point, kTolerance)));
     EXPECT_NEAR(case_.expected_closest[i].distance, dut.distance, kTolerance);
     EXPECT_EQ(case_.expected_closest[i].segment.idx_start, dut.segment.idx_start);
     EXPECT_EQ(case_.expected_closest[i].segment.idx_end, dut.segment.idx_end);
@@ -551,7 +555,7 @@ TEST_P(GetClosestPointIn2dLineStringTest, Test) {
   for (std::size_t i = 0; i < case_.eval_points.size(); ++i) {
     const auto dut = GetClosestPointUsing2dProjection(case_.line_string, case_.eval_points[i], kTolerance);
     EXPECT_NEAR(case_.expected_closest[i].p, dut.p, kTolerance);
-    EXPECT_TRUE(maliput::math::test::CompareVectors(case_.expected_closest[i].point, dut.point, kTolerance));
+    EXPECT_TRUE(AssertCompare(CompareVectors(case_.expected_closest[i].point, dut.point, kTolerance)));
     EXPECT_NEAR(case_.expected_closest[i].distance, dut.distance, kTolerance);
     EXPECT_EQ(case_.expected_closest[i].segment.idx_start, dut.segment.idx_start);
     EXPECT_EQ(case_.expected_closest[i].segment.idx_end, dut.segment.idx_end);


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/maliput/maliput/issues/602

## Summary
 - Do not use `maliput::test_utilities`'s compare methods.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
