### PR TITLE
Add RoadMarkingBook to RoadNetworkLoader.

### DIFF
--- a/src/loader/road_network_loader.cc
+++ b/src/loader/road_network_loader.cc
@@ -40,6 +40,7 @@
 #include <maliput/base/phase_based_right_of_way_rule_state_provider.h>
 #include <maliput/base/phase_ring_book_loader.h>
 #include <maliput/base/phased_discrete_rule_state_provider.h>
+#include <maliput/base/road_marking_book.h>
 #include <maliput/base/road_object_book.h>
 #include <maliput/base/road_rulebook_loader.h>
 #include <maliput/base/rule_registry.h>
@@ -151,7 +152,8 @@ std::unique_ptr<maliput::api::RoadNetwork> RoadNetworkLoader::operator()() {
       std::move(rg), std::move(rule_book), std::move(traffic_light_book), std::move(intersection_book),
       std::move(phase_ring_book), std::move(state_provider), std::move(phase_provider), std::move(rule_registry),
       std::move(discrete_value_rule_state_provider), std::move(range_value_rule_state_provider),
-      std::make_unique<maliput::RoadObjectBook>(), std::make_unique<maliput::TrafficSignBook>());
+      std::make_unique<maliput::RoadObjectBook>(), std::make_unique<maliput::TrafficSignBook>(),
+      std::make_unique<maliput::RoadMarkingBook>());
 }
 
 }  // namespace loader


### PR DESCRIPTION
# 🎉 New feature

Depends on https://github.com/maliput/maliput/pull/747

## Summary
Adds default `RoadMarkingBook` to `RoadNetworkLoader`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
